### PR TITLE
DINT-324 Map Commerce Payment codes to AEP payment enum values

### DIFF
--- a/packages/storefront-events-collector/src/__mocks__/alloy.ts
+++ b/packages/storefront-events-collector/src/__mocks__/alloy.ts
@@ -1,0 +1,15 @@
+/* TS wrapper around `@adobe/alloy`*/
+
+const configure = jest.fn(() => {return Promise.resolve(jest.fn(() => {return undefined}))})
+
+const getAlloy = jest.fn(() => {return Promise.resolve(jest.fn(() => {return undefined}))})
+
+const sendEvent = jest.fn(() => {
+    return Promise.resolve(undefined);
+})
+
+const hasConfig = jest.fn(() => { return true;});
+
+const setConsent = jest.fn(() => { return Promise.resolve(undefined);})
+
+export { configure, getAlloy, hasConfig, sendEvent, setConsent };

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -2,6 +2,25 @@ import * as sdkSchemas from "@adobe/magento-storefront-events-sdk/dist/types/typ
 
 import { Order, Payment } from "../../types/aep";
 
+const getAepPaymentCode = (paymentMethodCode: string) => {
+    switch (paymentMethodCode) {
+        case 'checkmo':
+            return 'check';
+        case 'banktransfer':
+            return 'wire_transfer';
+        case 'cashondelivery':
+            return 'cash';
+        case 'purchaseorder':
+            return 'other';
+        case 'free':
+            return 'other';
+        case 'companycredit':
+            return 'other';
+        default:
+            return 'other';
+    }
+}
+
 const createOrder = (
     orderContext: sdkSchemas.Order,
     storefrontInstanceContext: sdkSchemas.StorefrontInstance,
@@ -13,8 +32,7 @@ const createOrder = (
         payments = orderContext.payments.map((payment) => {
             return {
                 paymentAmount: payment.total,
-                // todo ahammond these should be an enum, change in sdk, retest (DINT-324)
-                paymentType: payment.paymentMethodCode,
+                paymentType: getAepPaymentCode(payment.paymentMethodCode),
                 transactionID: orderContext.orderId.toString(),
             };
         });
@@ -23,8 +41,7 @@ const createOrder = (
         payments = [
             {
                 paymentAmount: orderContext.grandTotal,
-                // todo ahammond these should be an enum, change in sdk, retest (DINT-324)
-                paymentType: orderContext.paymentMethodCode,
+                paymentType: getAepPaymentCode(orderContext.paymentMethodCode),
                 transactionID: orderContext.orderId.toString(),
             },
         ];

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -3,6 +3,7 @@ import * as sdkSchemas from "@adobe/magento-storefront-events-sdk/dist/types/typ
 import { Order, Payment } from "../../types/aep";
 
 const getAepPaymentCode = (paymentMethodCode: string) => {
+    //Code support reasoning documented here: https://jira.corp.adobe.com/browse/DINT-324
     switch (paymentMethodCode) {
         case 'checkmo':
             return 'check';
@@ -11,11 +12,8 @@ const getAepPaymentCode = (paymentMethodCode: string) => {
         case 'cashondelivery':
             return 'cash';
         case 'purchaseorder':
-            return 'other';
         case 'free':
-            return 'other';
         case 'companycredit':
-            return 'other';
         default:
             return 'other';
     }

--- a/packages/storefront-events-collector/tests/handlers/checkout/placeOrderAEP.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/checkout/placeOrderAEP.test.ts
@@ -18,11 +18,13 @@ test("correctly structures AEP event and calls alloy.sendEvent", () => {
             purchaseID: '111111',
             currencyCode: 'USD',
             payments: [{
+                "currencyCode": "USD",
                 "paymentAmount": 30,
                 "paymentType": "other",
                 "transactionID": "111111",
                 },
                 {
+                "currencyCode": "USD",
                 "paymentAmount": 39.98,
                 "paymentType": "other",
                 "transactionID": "111111",

--- a/packages/storefront-events-collector/tests/handlers/checkout/placeOrderAEP.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/checkout/placeOrderAEP.test.ts
@@ -1,0 +1,60 @@
+jest.mock('../../../src/alloy');
+import { sendEvent } from "../../../src/alloy";
+import { placeOrderHandlerAEP } from "../../../src/handlers";
+import { mockEvent } from "../../utils/mocks";
+
+const AEPevent = {...mockEvent};
+delete AEPevent.eventInfo.customContext;
+
+
+test("correctly structures AEP event and calls alloy.sendEvent", () => {
+    placeOrderHandlerAEP(mockEvent);
+
+    expect(sendEvent).toHaveBeenCalledTimes(1);
+
+    expect(sendEvent).toHaveBeenCalledWith({
+        commerce: {
+            order: {
+            purchaseID: '111111',
+            currencyCode: 'USD',
+            payments: [{
+                "paymentAmount": 30,
+                "paymentType": "other",
+                "transactionID": "111111",
+                },
+                {
+                "paymentAmount": 39.98,
+                "paymentType": "other",
+                "transactionID": "111111",
+            }],
+            orderType: 'checkout'
+            },
+            promotionID: '',
+            shipping: { shippingMethod: 'ground', shippingAmount: 5.99 },
+            purchases: { value: 1 }
+        },
+        productListItems: [
+            {
+            SKU: 'ts001',
+            name: 'T-Shirt',
+            quantity: 1,
+            priceTotal: 20,
+            currencyCode: 'USD',
+            discountAmount: 0,
+            selectedOptions: []
+            },
+            {
+            SKU: 'h001',
+            name: 'Hoodie',
+            quantity: 1,
+            priceTotal: 50,
+            currencyCode: 'USD',
+            discountAmount: 0,
+            selectedOptions: []
+            }
+        ],
+        _id: undefined,
+        eventType: 'commerce.order'
+          
+    });
+});

--- a/packages/storefront-events-collector/tests/utils/setup.ts
+++ b/packages/storefront-events-collector/tests/utils/setup.ts
@@ -1,5 +1,3 @@
-import "@adobe/adobe-client-data-layer";
-
 import mse from "@adobe/magento-storefront-events-sdk";
 
 import {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding mapping from commerce payment codes, to enums supported in AEP for payment types.

## Related Issue

[[<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->](https://jira.corp.adobe.com/browse/DINT-324)](https://jira.corp.adobe.com/browse/DINT-324)

## Motivation and Context

https://jira.corp.adobe.com/browse/DINT-324

## How Has This Been Tested?

Using the testing script in combination with the AEP debugger check that payment type is being sent as the mapped value versus the mocked value.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x ] All new and existing tests passed.
