### PR TITLE
SEG-8: [segment-collector] Proxy Service call for AEP segmentation

### DIFF
--- a/packages/commerce-events-collector-segments/package.json
+++ b/packages/commerce-events-collector-segments/package.json
@@ -36,7 +36,8 @@
         "test": "jest --passWithNoTests",
         "test:ci": "jest --passWithNoTests --ci",
         "test:watch": "jest --passWithNoTests --watch",
-        "release": "cross-env HUSKY_SKIP_HOOKS=1 standard-version"
+        "release": "cross-env HUSKY_SKIP_HOOKS=1 standard-version",
+        "pre-commit:clean": "rm -rf dist/ coverage/ && yarn lint && yarn format && yarn test && yarn build"
     },
     "dependencies": {
         "@adobe/commerce-events-sdk": "*",

--- a/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getECID.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getECID.ts
@@ -1,5 +1,5 @@
 // Get ECID from alloy
-import { AlloyIdentity } from "src/aep/types";
+import { AlloyIdentity } from "../../aep/types";
 
 const getECID = (): Promise<string | void> => {
     return new Promise((resolve, reject): string | void => {

--- a/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getECID.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getECID.ts
@@ -1,6 +1,5 @@
 // Get ECID from alloy
-
-import { AlloyIdentity } from "./aep/types";
+import { AlloyIdentity } from "src/aep/types";
 
 const getECID = (): Promise<string | void> => {
     return new Promise((resolve, reject): string | void => {

--- a/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/index.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/index.ts
@@ -1,0 +1,1 @@
+export { default as getECID } from "./getECID";

--- a/packages/commerce-events-collector-segments/src/handlers/apiIntegration/getAEPSegmentsFromProxyService.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/apiIntegration/getAEPSegmentsFromProxyService.ts
@@ -3,35 +3,35 @@
  * as the default `options` should be fine.
  */
 const apiFetchOptions: RequestInit = {
-    method: 'GET',
-    mode: 'cors',
-    cache: 'no-cache',
+    method: "GET",
+    mode: "cors",
+    cache: "no-cache",
     headers: {
-        'content-type': 'application/json;charset=UTF-8',
-    }
+        "content-type": "application/json;charset=UTF-8",
+    },
 };
 
 /**
- * 
+ * Call segments proxy service and get a list of segment ids for current user
+ *
  * @param profileId - ECID of current user, should be retrieved from Ally
- * 
+ *
  * @returns Promise with returend data from adobe segment proxy service
  */
-const getAEPSegmentsFromProxyService = (profileId:string): Promise<string | void> => {
-
+const getAEPSegmentsFromProxyService = (profileId: string): Promise<string | void> => {
     // static api_key that is used for the proxy service
-    const API_KEY = "commerce-segments-service"; 
+    const API_KEY = "commerce-segments-service";
 
     // static imsOrgId used for the proxy service, this should eventually come from Alloy, but this script needs to be integrated into the extension to test access to the `imsOrgId`
     const imsOrgId = "53A16ACB5CC1D3760A495C99@AdobeOrg";
-    
+
     // URL to access the segments proxy service, this will most likely come from a config file or service after POC
     const GET_AEP_SEGMENTS_ENDPOINT_URL = `https://commerce-int.adobe.io/segments/segments-service/profiles/${profileId}}/segmentmemberships?imsOrgId=${imsOrgId}}&api_key=${API_KEY}`;
 
     return new Promise((resolve, reject): string | void => {
         fetch(GET_AEP_SEGMENTS_ENDPOINT_URL, apiFetchOptions)
-            .then(response => response.json())
-            .then(responseData => {
+            .then((response) => response.json())
+            .then((responseData) => {
                 /*
                     JSON object that comes back is in a structure like: 
                     {
@@ -47,12 +47,12 @@ const getAEPSegmentsFromProxyService = (profileId:string): Promise<string | void
                     So we need to just get `segmentMembershipIds` and combine that into a comma delimited string.  
                     @Note: Once this is finalized could just destructure it out of the `responseData`, i.e. ({data:{segmentMembershipIds = []} = {}})
                 */
-                resolve(responseData?.data?.segmentMembershipIds?.join(",") || "")
+                resolve(responseData?.data?.segmentMembershipIds?.join(",") || "");
             })
-            .catch(error => {
+            .catch((error) => {
                 reject(error);
-            })
-    }
+            });
+    });
 };
 
 export default getAEPSegmentsFromProxyService;

--- a/packages/commerce-events-collector-segments/src/handlers/apiIntegration/getAEPSegmentsFromProxyService.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/apiIntegration/getAEPSegmentsFromProxyService.ts
@@ -1,0 +1,58 @@
+/**
+ * Options to use for the fetch method, this is really only here for development purposes while we get everythign deployed
+ * as the default `options` should be fine.
+ */
+const apiFetchOptions: RequestInit = {
+    method: 'GET',
+    mode: 'cors',
+    cache: 'no-cache',
+    headers: {
+        'content-type': 'application/json;charset=UTF-8',
+    }
+};
+
+/**
+ * 
+ * @param profileId - ECID of current user, should be retrieved from Ally
+ * 
+ * @returns Promise with returend data from adobe segment proxy service
+ */
+const getAEPSegmentsFromProxyService = (profileId:string): Promise<string | void> => {
+
+    // static api_key that is used for the proxy service
+    const API_KEY = "commerce-segments-service"; 
+
+    // static imsOrgId used for the proxy service, this should eventually come from Alloy, but this script needs to be integrated into the extension to test access to the `imsOrgId`
+    const imsOrgId = "53A16ACB5CC1D3760A495C99@AdobeOrg";
+    
+    // URL to access the segments proxy service, this will most likely come from a config file or service after POC
+    const GET_AEP_SEGMENTS_ENDPOINT_URL = `https://commerce-int.adobe.io/segments/segments-service/profiles/${profileId}}/segmentmemberships?imsOrgId=${imsOrgId}}&api_key=${API_KEY}`;
+
+    return new Promise((resolve, reject): string | void => {
+        fetch(GET_AEP_SEGMENTS_ENDPOINT_URL, apiFetchOptions)
+            .then(response => response.json())
+            .then(responseData => {
+                /*
+                    JSON object that comes back is in a structure like: 
+                    {
+                        "data": {
+                            "segmentMembershipIds": [
+                                "abc-123",
+                                "def-456",
+                                "ghi-789"
+                            ]
+                        },
+                        "signature": "<hashed signature string>"
+                    }
+                    So we need to just get `segmentMembershipIds` and combine that into a comma delimited string.  
+                    @Note: Once this is finalized could just destructure it out of the `responseData`, i.e. ({data:{segmentMembershipIds = []} = {}})
+                */
+                resolve(responseData?.data?.segmentMembershipIds?.join(",") || "")
+            })
+            .catch(error => {
+                reject(error);
+            })
+    }
+};
+
+export default getAEPSegmentsFromProxyService;

--- a/packages/commerce-events-collector-segments/src/handlers/apiIntegration/getAEPSegmentsFromProxyService.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/apiIntegration/getAEPSegmentsFromProxyService.ts
@@ -14,7 +14,7 @@ const apiFetchOptions: RequestInit = {
 /**
  * Call segments proxy service and get a list of segment ids for current user
  *
- * @param profileId - ECID of current user, should be retrieved from Ally
+ * @param profileId - ECID of current user, should be retrieved from Alloy
  *
  * @returns Promise with returend data from adobe segment proxy service
  */
@@ -22,8 +22,9 @@ const getAEPSegmentsFromProxyService = (profileId: string): Promise<string | voi
     // static api_key that is used for the proxy service
     const API_KEY = "commerce-segments-service";
 
-    // static imsOrgId used for the proxy service, this should eventually come from Alloy, but this script needs to be integrated into the extension to test access to the `imsOrgId`
-    const imsOrgId = "53A16ACB5CC1D3760A495C99@AdobeOrg";
+    // get a reference to the magento storefront events context. This will give us access to the AEP data
+    const { context } = window.magentoStorefrontEvents;
+    const { imsOrgId = "" } = context.getAEP();
 
     // URL to access the segments proxy service, this will most likely come from a config file or service after POC
     const GET_AEP_SEGMENTS_ENDPOINT_URL = `https://commerce-int.adobe.io/segments/segments-service/profiles/${profileId}}/segmentmemberships?imsOrgId=${imsOrgId}}&api_key=${API_KEY}`;

--- a/packages/commerce-events-collector-segments/src/handlers/apiIntegration/index.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/apiIntegration/index.ts
@@ -1,0 +1,1 @@
+export { default as getAEPSegmentsFromProxyService } from "./getAEPSegmentsFromProxyService";

--- a/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/index.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/index.ts
@@ -1,0 +1,1 @@
+export { default as setAdobeCommerceSegmentCookies } from "./setAdobeCommerceSegmentCookies";

--- a/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/setAdobeCommerceSegmentCookies.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/setAdobeCommerceSegmentCookies.ts
@@ -1,0 +1,21 @@
+/**
+ * The name of the cookie to save so that adobe commerce can read in the segment information.
+ *
+ * Should match up with Github located at:
+ * @link https://github.com/magento-commerce/segments-service/blob/poc/Segment/Model/SegmentResolver.php#L12
+ */
+const ADOBE_COMMERCE_SHOPPER_SEGMENT = "adobe_segment";
+
+/**
+ * Set the browser cookies with the returned segmentMembershipIds from the proxy service
+ *
+ * @note for now we'll keep the `expires` param for cookies set to default.
+ *
+ * @param segmentMembershipIds comma delimited string of `segmentMembershipIds` that is returned from the proxy service
+ */
+const setAdobeCommerceSegmentCookies = (segmentMembershipIds = "") => {
+    //again, note that no expiration is set, so this will be a session cookie
+    document.cookie = `${ADOBE_COMMERCE_SHOPPER_SEGMENT}=${segmentMembershipIds}`;
+};
+
+export default setAdobeCommerceSegmentCookies;

--- a/packages/commerce-events-collector-segments/src/index.ts
+++ b/packages/commerce-events-collector-segments/src/index.ts
@@ -1,24 +1,19 @@
-import { getAEPSegmentsFromProxyService } from "src/handlers/apiIntegration";
-import { setAdobeCommerceSegmentCookies } from "src/handlers/browserCookieIntegration";
-import { getECID } from "src/handlers/alloyIntegration";
+import { getAEPSegmentsFromProxyService } from "./handlers/apiIntegration";
+import { setAdobeCommerceSegmentCookies } from "./handlers/browserCookieIntegration";
+import { getECID } from "./handlers/alloyIntegration";
 
 /**
  * Initialize the commerce-events-collector workflow
  */
 const initialize = async () => {
-    getECID()
-        .then((ecid: string) => {
-            getAEPSegmentsFromProxyService(ecid)
-                .then((segmentMembershipIds: string) => {
-                    setAdobeCommerceSegmentCookies(segmentMembershipIds)
-                })
-                .catch(error => {
-                    console.error("Error on getting proxy service data; ", error);
-                })
-        })
-        .catch(error => {
-            console.error("Error on getting `ECID`: ", error);
-        })
+    try {
+        const ecid: string = (await getECID()) || "";
+        const segmentMembershipIds: string = (await getAEPSegmentsFromProxyService(ecid)) || "";
+
+        setAdobeCommerceSegmentCookies(segmentMembershipIds);
+    } catch (error) {
+        console.warn("Error on getting segments: ", error);
+    }
 };
 
 initialize();

--- a/packages/commerce-events-collector-segments/src/index.ts
+++ b/packages/commerce-events-collector-segments/src/index.ts
@@ -1,1 +1,24 @@
-export * from "./getECID";
+import { getAEPSegmentsFromProxyService } from "src/handlers/apiIntegration";
+import { setAdobeCommerceSegmentCookies } from "src/handlers/browserCookieIntegration";
+import { getECID } from "src/handlers/alloyIntegration";
+
+/**
+ * Initialize the commerce-events-collector workflow
+ */
+const initialize = async () => {
+    getECID()
+        .then((ecid: string) => {
+            getAEPSegmentsFromProxyService(ecid)
+                .then((segmentMembershipIds: string) => {
+                    setAdobeCommerceSegmentCookies(segmentMembershipIds)
+                })
+                .catch(error => {
+                    console.error("Error on getting proxy service data; ", error);
+                })
+        })
+        .catch(error => {
+            console.error("Error on getting `ECID`: ", error);
+        })
+};
+
+initialize();

--- a/packages/commerce-events-collector-segments/src/types/index.d.ts
+++ b/packages/commerce-events-collector-segments/src/types/index.d.ts
@@ -1,7 +1,9 @@
+import { MagentoStorefrontEvents } from "@adobe/commerce-events-sdk";
 import { AlloyInstance } from "../aep/types";
 
 declare global {
     interface Window {
+        magentoStorefrontEvents: MagentoStorefrontEvents;
         alloy: AlloyInstance;
     }
 }

--- a/packages/commerce-events-collector-segments/tests/handlers/alloyIntegration/getECID.test.ts
+++ b/packages/commerce-events-collector-segments/tests/handlers/alloyIntegration/getECID.test.ts
@@ -1,4 +1,4 @@
-import getECID from "../src/getECID";
+import { getECID } from "../../../src/handlers/alloyIntegration";
 
 describe("Get ECID function", () => {
     it("Should throw correct error message if alloy is not available", async () => {

--- a/packages/commerce-events-collector-segments/tests/utils/setup.ts
+++ b/packages/commerce-events-collector-segments/tests/utils/setup.ts
@@ -1,1 +1,3 @@
-import getECID from "../../src/getECID";
+import { getAEPSegmentsFromProxyService } from "../../src/handlers/apiIntegration";
+import { setAdobeCommerceSegmentCookies } from "../../src/handlers/browserCookieIntegration";
+import { getECID } from "../../src/handlers/alloyIntegration";


### PR DESCRIPTION
## Description

- Implemented SEG-4 functionality
- Implemented proxy service call for segments-collector
- published commerce-segment ids to the browser cookies for testing

## Related Issue

[segment-collector: SEG-8](https://jira.corp.adobe.com/browse/SEG-8)

## Motivation and Context

POC for implementing segments into an adobe commerce store

## How Has This Been Tested?

Locally via unit tests, and partially via loaded script locally.  Will need to do more testing once its deployed via "unpkg"

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [X] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
