### PR TITLE
SEG-8: [segment-collector] Proxy Service call for AEP segmentation

### DIFF
--- a/packages/commerce-events-collector-segments/src/index.ts
+++ b/packages/commerce-events-collector-segments/src/index.ts
@@ -11,6 +11,9 @@ const initialize = async () => {
     try {
         const ecid: string = (await getECID()) || "";
 
+        //call the proxy service the first time, then do it on a timely manner afterwards.
+        callProxyService(ecid);
+
         // need to call proxy service every set amount of time and retrieve updated segment information
         setInterval(callProxyService, PROXY_SERVICE_CALL_INTERVAL, ecid);
     } catch (error) {


### PR DESCRIPTION
## Description

- bug fix where proxy call isnt doing an initial call before setting the interval

## Related Issue

[segment-collector: SEG-8](https://jira.corp.adobe.com/browse/SEG-8)

## Motivation and Context

POC for implementing segments into an adobe commerce store

## How Has This Been Tested?

Locally via unit tests, and partially via loaded script locally.  Will need to do more testing once its deployed via "unpkg"

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
