### PR TITLE
DINT-641: experience platform connector extension context

### DIFF
--- a/examples/old-collector-example/index.js
+++ b/examples/old-collector-example/index.js
@@ -1,6 +1,7 @@
 import {
     mockAccount,
     mockDataServicesExtension,
+    mockExperiencePlatformConnectorExtenion,
     mockExtension,
     mockOrder,
     mockPage,
@@ -20,6 +21,7 @@ const mse = window.magentoStorefrontEvents;
 mse.context.setAccount(mockAccount);
 mse.context.setMagentoExtension(mockExtension);
 mse.context.setDataServicesExtension(mockDataServicesExtension);
+mse.context.setExperiencePlatformConnectorExtension(mockExperiencePlatformConnectorExtenion);
 mse.context.setRecommendationsExtension(mockRecommendationsExtension);
 mse.context.setSearchExtension(mockSearchExtension);
 mse.context.setOrder(mockOrder);

--- a/packages/commerce-events-collectors/src/contexts/experiencePlatformConnectorExtension.ts
+++ b/packages/commerce-events-collectors/src/contexts/experiencePlatformConnectorExtension.ts
@@ -1,0 +1,29 @@
+import schemas from "../schemas";
+import { ExperiencePlatformConnectorExtension } from "@adobe/commerce-events-sdk";
+
+import { ExperiencePlatformConnectorExtensionContext } from "../types/contexts";
+
+const createContext = (
+    extension?: ExperiencePlatformConnectorExtension,
+): ExperiencePlatformConnectorExtensionContext => {
+    const mse = window.magentoStorefrontEvents;
+    const experiencePlatformExtensionCtx = extension ?? mse.context.getExperiencePlatformConnectorExtension();
+
+    if (!experiencePlatformExtensionCtx) {
+        return {
+            schema: schemas.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL,
+            data: {},
+        };
+    }
+
+    const context = {
+        schema: schemas.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL,
+        data: {
+            version: experiencePlatformExtensionCtx.version,
+        },
+    };
+
+    return context;
+};
+
+export default createContext;

--- a/packages/commerce-events-collectors/src/contexts/index.ts
+++ b/packages/commerce-events-collectors/src/contexts/index.ts
@@ -1,5 +1,6 @@
 export { default as createDataServicesExtensionCtx } from "./dataServicesExtension";
 export { default as createEventForwardingCtx } from "./eventForwarding";
+export { default as createExperiencePlatformConnectorExtensionCtx } from "./experiencePlatformConnectorExtension";
 export { default as createMagentoExtensionCtx } from "./extension";
 export { default as createProductCtx } from "./product";
 export { default as createRecommendationsExtensionCtx } from "./recommendationsExtension";

--- a/packages/commerce-events-collectors/src/contexts/snowplow.ts
+++ b/packages/commerce-events-collectors/src/contexts/snowplow.ts
@@ -2,6 +2,7 @@ import { ContextPrimitive } from "@snowplow/tracker-core";
 
 import {
     createDataServicesExtensionCtx,
+    createExperiencePlatformConnectorExtensionCtx,
     createMagentoExtensionCtx,
     createRecommendationsExtensionCtx,
     createSearchExtensionCtx,
@@ -16,6 +17,7 @@ const createContext = (): Array<ContextPrimitive> => {
         () => createStorefrontInstanceCtx(),
         () => createMagentoExtensionCtx(),
         () => createDataServicesExtensionCtx(),
+        () => createExperiencePlatformConnectorExtensionCtx(),
         () => createRecommendationsExtensionCtx(),
         () => createSearchExtensionCtx(),
         () => createShopperCtx(),

--- a/packages/commerce-events-collectors/src/schemas.ts
+++ b/packages/commerce-events-collectors/src/schemas.ts
@@ -3,6 +3,8 @@ const schemas = {
     DATA_SERVICES_EXTENSION_SCHEMA_URL: "iglu:com.adobe.magento.entity/data-services-extension/jsonschema/1-0-1",
     RECOMMENDATIONS_EXTENSION_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendations-extension/jsonschema/1-0-0",
     SEARCH_EXTENSION_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-extension/jsonschema/1-0-0",
+    EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL:
+        "iglu:com.adobe.magento.entity/experience-platform-connector-extension/jsonschema/1-0-0",
     MAGENTO_JS_TRACKER_SCHEMA_URL: "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/2-0-0",
     PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-0-4",
     RECOMMENDATION_UNIT_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",

--- a/packages/commerce-events-collectors/src/types/contexts.d.ts
+++ b/packages/commerce-events-collectors/src/types/contexts.d.ts
@@ -9,6 +9,10 @@ type DataServicesExtension = {
     version: string;
 };
 
+type ExperiencePlatformExtension = {
+    version: string;
+};
+
 type RecommendationsExtension = {
     version: string;
 };
@@ -239,6 +243,7 @@ type SnowplowContext<DataType> = SelfDescribingJson<DataType | Record<string, un
 
 type ExtensionContext = SnowplowContext<Extension>;
 type DataServicesExtensionContext = SnowplowContext<DataServicesExtension>;
+type ExperiencePlatformConnectorExtensionContext = SnowplowContext<ExperiencePlatformConnectorExtension>;
 type RecommendationsExtensionContext = SnowplowContext<RecommendationsExtension>;
 type SearchExtensionContext = SnowplowContext<SearchExtension>;
 type ProductContext = SnowplowContext<Product>;

--- a/packages/commerce-events-collectors/tests/contexts/experiencePlatformConnectorExtension.test.ts
+++ b/packages/commerce-events-collectors/tests/contexts/experiencePlatformConnectorExtension.test.ts
@@ -1,0 +1,12 @@
+import { createExperiencePlatformConnectorExtensionCtx } from "../../src/contexts";
+import schemas from "../../src/schemas";
+import { mockExperiencePlatformExtensionCtx } from "../utils/mocks";
+
+test("creates context", () => {
+    const ctx = createExperiencePlatformConnectorExtensionCtx();
+
+    expect(ctx).toEqual({
+        data: mockExperiencePlatformExtensionCtx,
+        schema: schemas.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL,
+    });
+});

--- a/packages/commerce-events-collectors/tests/contexts/snowplow.test.ts
+++ b/packages/commerce-events-collectors/tests/contexts/snowplow.test.ts
@@ -11,5 +11,6 @@ test("creates context", () => {
         expect.any(Function),
         expect.any(Function),
         expect.any(Function),
+        expect.any(Function),
     ]);
 });

--- a/packages/commerce-events-collectors/tests/utils/mocks/context.ts
+++ b/packages/commerce-events-collectors/tests/utils/mocks/context.ts
@@ -99,6 +99,10 @@ const mockDataServicesExtensionCtx = {
     version: "1.2.3",
 };
 
+const mockExperiencePlatformExtensionCtx = {
+    version: "1.2.3",
+};
+
 const mockRecommendationsExtensionCtx = {
     version: "1.2.3",
 };
@@ -308,6 +312,7 @@ export {
     mockAepCtx,
     mockDataServicesExtensionCtx,
     mockEventForwardingCtx,
+    mockExperiencePlatformExtensionCtx,
     mockExtensionCtx,
     mockProductCtx,
     mockRecommendationsExtensionCtx,

--- a/packages/commerce-events-collectors/tests/utils/mocks/dataLayer.ts
+++ b/packages/commerce-events-collectors/tests/utils/mocks/dataLayer.ts
@@ -5,6 +5,7 @@ import {
     CustomUrl,
     DataServicesExtension,
     Event,
+    ExperiencePlatformConnectorExtension,
     MagentoExtension,
     Order,
     Page,
@@ -92,6 +93,10 @@ const mockExtension: MagentoExtension = {
 };
 
 const mockDataServicesExtension: DataServicesExtension = {
+    version: "1.2.3",
+};
+
+const mockExperiencePlatformConnectorExtenion: ExperiencePlatformConnectorExtension = {
     version: "1.2.3",
 };
 
@@ -522,6 +527,7 @@ export {
     mockChangedProducts,
     mockDataServicesExtension,
     mockEvent,
+    mockExperiencePlatformConnectorExtenion,
     mockExtension,
     mockOrder,
     mockPage,

--- a/packages/commerce-events-collectors/tests/utils/setup.ts
+++ b/packages/commerce-events-collectors/tests/utils/setup.ts
@@ -5,6 +5,7 @@ import MagentoStorefrontEvents from "@adobe/commerce-events-sdk/src/MagentoStore
 import {
     mockCategory,
     mockDataServicesExtension,
+    mockExperiencePlatformConnectorExtenion,
     mockExtension,
     mockOrder,
     mockPage,
@@ -28,6 +29,7 @@ window.magentoStorefrontEvents = mse;
 mse.context.setCategory(mockCategory);
 mse.context.setMagentoExtension(mockExtension);
 mse.context.setDataServicesExtension(mockDataServicesExtension);
+mse.context.setExperiencePlatformConnectorExtension(mockExperiencePlatformConnectorExtenion);
 mse.context.setRecommendationsExtension(mockRecommendationsExtension);
 mse.context.setSearchExtension(mockSearchExtension);
 mse.context.setOrder(mockOrder);

--- a/packages/commerce-events-sdk/README.md
+++ b/packages/commerce-events-sdk/README.md
@@ -196,6 +196,14 @@ Sets the `DataServicesExtension` context. Includes Data Services extension versi
 
 -   [context schema definition](https://github.com/adobe/commerce-events/tree/main/packages/commerce-events-sdk/src/types/schemas/dataServicesExtension.ts)
 
+#### `setExperiencePlatformConnectorExtension`
+
+```javascript
+mse.context.setExperiencePlatformConnectorExtension(experiencePlatformConnectorExtensionCtx);
+```
+
+Sets the `ExperiencePlatformConnectorExtension` context. Includes Experience Platform Connector extension version.
+
 #### `setOrder`
 
 ```javascript

--- a/packages/commerce-events-sdk/src/ContextManager.ts
+++ b/packages/commerce-events-sdk/src/ContextManager.ts
@@ -8,6 +8,7 @@ import {
     CustomUrl,
     Debug,
     EventForwarding,
+    ExperiencePlatformConnectorExtension,
     MagentoExtension,
     Order,
     Page,
@@ -71,6 +72,19 @@ export default class ContextManager extends Base {
 
     setEventForwarding(context: EventForwarding): void {
         this.setContext<EventForwarding>(contexts.EVENT_FORWARDING_CONTEXT, context);
+    }
+
+    getExperiencePlatformConnectorExtension(): ExperiencePlatformConnectorExtension {
+        return this.getContext<ExperiencePlatformConnectorExtension>(
+            contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT,
+        );
+    }
+
+    setExperiencePlatformConnectorExtension(context: ExperiencePlatformConnectorExtension): void {
+        this.setContext<ExperiencePlatformConnectorExtension>(
+            contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT,
+            context,
+        );
     }
 
     getCustomUrl(): CustomUrl {

--- a/packages/commerce-events-sdk/src/contexts.ts
+++ b/packages/commerce-events-sdk/src/contexts.ts
@@ -7,6 +7,7 @@ const contexts = {
     DATA_SERVICES_EXTENSION_CONTEXT: "dataServicesExtensionContext",
     DEBUG_CONTEXT: "debugContext",
     EVENT_FORWARDING_CONTEXT: "eventForwardingContext",
+    EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT: "experiencePlatformConnectorExtensionContext",
     MAGENTO_EXTENSION_CONTEXT: "magentoExtensionContext",
     ORDER_CONTEXT: "orderContext",
     PAGE_CONTEXT: "pageContext",

--- a/packages/commerce-events-sdk/src/types/contexts.ts
+++ b/packages/commerce-events-sdk/src/types/contexts.ts
@@ -8,6 +8,7 @@ import {
     DataServicesExtension,
     Debug,
     EventForwarding,
+    ExperiencePlatformConnectorExtension,
     MagentoExtension,
     Order,
     Page,
@@ -31,6 +32,7 @@ export type ContextName =
     | typeof contexts.DATA_SERVICES_EXTENSION_CONTEXT
     | typeof contexts.DEBUG_CONTEXT
     | typeof contexts.EVENT_FORWARDING_CONTEXT
+    | typeof contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT
     | typeof contexts.MAGENTO_EXTENSION_CONTEXT
     | typeof contexts.ORDER_CONTEXT
     | typeof contexts.PAGE_CONTEXT
@@ -54,6 +56,7 @@ export type Context = {
     [contexts.DATA_SERVICES_EXTENSION_CONTEXT]?: DataServicesExtension;
     [contexts.DEBUG_CONTEXT]?: Debug;
     [contexts.EVENT_FORWARDING_CONTEXT]?: EventForwarding;
+    [contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT]?: ExperiencePlatformConnectorExtension;
     [contexts.MAGENTO_EXTENSION_CONTEXT]: MagentoExtension;
     [contexts.ORDER_CONTEXT]: Order;
     [contexts.PAGE_CONTEXT]: Page;

--- a/packages/commerce-events-sdk/src/types/schemas/experiencePlatformConnectorExtension.ts
+++ b/packages/commerce-events-sdk/src/types/schemas/experiencePlatformConnectorExtension.ts
@@ -1,0 +1,4 @@
+/* information about the EPC PHP extension */
+export type ExperiencePlatformConnectorExtension = {
+    version: string;
+};

--- a/packages/commerce-events-sdk/src/types/schemas/index.ts
+++ b/packages/commerce-events-sdk/src/types/schemas/index.ts
@@ -7,6 +7,7 @@ export * from "./customUrl";
 export * from "./dataServicesExtension";
 export * from "./debug";
 export * from "./eventForwarding";
+export * from "./experiencePlatformConnectorExtension";
 export * from "./magentoExtension";
 export * from "./order";
 export * from "./page";

--- a/packages/storefront-events-collector/src/contexts/experiencePlatformConnectorExtension.ts
+++ b/packages/storefront-events-collector/src/contexts/experiencePlatformConnectorExtension.ts
@@ -1,0 +1,30 @@
+import schemas from "../schemas";
+
+import { ExperiencePlatformConnectorExtension } from "@adobe/commerce-events-sdk";
+
+import { ExperiencePlatformConnectorExtensionContext } from "../types/contexts";
+
+const createContext = (
+    extension?: ExperiencePlatformConnectorExtension,
+): ExperiencePlatformConnectorExtensionContext => {
+    const mse = window.magentoStorefrontEvents;
+    const experiencePlatformExtensionCtx = extension ?? mse.context.getExperiencePlatformConnectorExtension();
+
+    if (!experiencePlatformExtensionCtx) {
+        return {
+            schema: schemas.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL,
+            data: {},
+        };
+    }
+
+    const context = {
+        schema: schemas.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL,
+        data: {
+            version: experiencePlatformExtensionCtx.version,
+        },
+    };
+
+    return context;
+};
+
+export default createContext;

--- a/packages/storefront-events-collector/src/contexts/index.ts
+++ b/packages/storefront-events-collector/src/contexts/index.ts
@@ -1,5 +1,6 @@
 export { default as createDataServicesExtensionCtx } from "./dataServicesExtension";
 export { default as createEventForwardingCtx } from "./eventForwarding";
+export { default as createExperiencePlatformConnectorExtensionCtx } from "./experiencePlatformConnectorExtension";
 export { default as createMagentoExtensionCtx } from "./extension";
 export { default as createProductCtx } from "./product";
 export { default as createRecommendationsExtensionCtx } from "./recommendationsExtension";

--- a/packages/storefront-events-collector/src/contexts/snowplow.ts
+++ b/packages/storefront-events-collector/src/contexts/snowplow.ts
@@ -2,6 +2,7 @@ import { ContextPrimitive } from "@snowplow/tracker-core";
 
 import {
     createDataServicesExtensionCtx,
+    createExperiencePlatformConnectorExtensionCtx,
     createMagentoExtensionCtx,
     createRecommendationsExtensionCtx,
     createSearchExtensionCtx,
@@ -16,6 +17,7 @@ const createContext = (): Array<ContextPrimitive> => {
         () => createStorefrontInstanceCtx(),
         () => createMagentoExtensionCtx(),
         () => createDataServicesExtensionCtx(),
+        () => createExperiencePlatformConnectorExtensionCtx(),
         () => createRecommendationsExtensionCtx(),
         () => createSearchExtensionCtx(),
         () => createShopperCtx(),

--- a/packages/storefront-events-collector/src/schemas.ts
+++ b/packages/storefront-events-collector/src/schemas.ts
@@ -3,6 +3,8 @@ const schemas = {
     DATA_SERVICES_EXTENSION_SCHEMA_URL: "iglu:com.adobe.magento.entity/data-services-extension/jsonschema/1-0-1",
     RECOMMENDATIONS_EXTENSION_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendations-extension/jsonschema/1-0-0",
     SEARCH_EXTENSION_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-extension/jsonschema/1-0-0",
+    EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL:
+        "iglu:com.adobe.magento.entity/experience-platform-connector-extension/jsonschema/1-0-0",
     MAGENTO_JS_TRACKER_SCHEMA_URL: "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/2-0-0",
     PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-0-4",
     RECOMMENDATION_UNIT_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",

--- a/packages/storefront-events-collector/src/types/contexts.d.ts
+++ b/packages/storefront-events-collector/src/types/contexts.d.ts
@@ -9,6 +9,10 @@ type DataServicesExtension = {
     version: string;
 };
 
+type ExperiencePlatformConnectorExtension = {
+    version: string;
+};
+
 type RecommendationsExtension = {
     version: string;
 };
@@ -239,6 +243,7 @@ type SnowplowContext<DataType> = SelfDescribingJson<DataType | Record<string, un
 
 type ExtensionContext = SnowplowContext<Extension>;
 type DataServicesExtensionContext = SnowplowContext<DataServicesExtension>;
+type ExperiencePlatformConnectorExtensionContext = SnowplowContext<ExperiencePlatformConnectorExtension>;
 type RecommendationsExtensionContext = SnowplowContext<RecommendationsExtension>;
 type SearchExtensionContext = SnowplowContext<SearchExtension>;
 type ProductContext = SnowplowContext<Product>;

--- a/packages/storefront-events-collector/tests/contexts/experiencePlatformConnectorExtension.test.ts
+++ b/packages/storefront-events-collector/tests/contexts/experiencePlatformConnectorExtension.test.ts
@@ -1,0 +1,12 @@
+import { createExperiencePlatformConnectorExtensionCtx } from "../../src/contexts";
+import schemas from "../../src/schemas";
+import { mockExperiencePlatformExtensionCtx } from "../utils/mocks";
+
+test("creates context", () => {
+    const ctx = createExperiencePlatformConnectorExtensionCtx();
+
+    expect(ctx).toEqual({
+        data: mockExperiencePlatformExtensionCtx,
+        schema: schemas.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL,
+    });
+});

--- a/packages/storefront-events-collector/tests/contexts/snowplow.test.ts
+++ b/packages/storefront-events-collector/tests/contexts/snowplow.test.ts
@@ -11,5 +11,6 @@ test("creates context", () => {
         expect.any(Function),
         expect.any(Function),
         expect.any(Function),
+        expect.any(Function),
     ]);
 });

--- a/packages/storefront-events-collector/tests/utils/mocks/context.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/context.ts
@@ -101,6 +101,10 @@ const mockDataServicesExtensionCtx = {
     version: "1.2.3",
 };
 
+const mockExperiencePlatformExtensionCtx = {
+    version: "1.2.3",
+};
+
 const mockRecommendationsExtensionCtx = {
     version: "1.2.3",
 };
@@ -310,6 +314,7 @@ export {
     mockAepCtx,
     mockDataServicesExtensionCtx,
     mockEventForwardingCtx,
+    mockExperiencePlatformExtensionCtx,
     mockExtensionCtx,
     mockProductCtx,
     mockRecommendationsExtensionCtx,

--- a/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
@@ -1,3 +1,4 @@
+import { ExperiencePlatformConnectorExtension } from "@adobe/commerce-events-sdk";
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
 import {
     Account,
@@ -92,6 +93,10 @@ const mockExtension: MagentoExtension = {
 };
 
 const mockDataServicesExtension: DataServicesExtension = {
+    version: "1.2.3",
+};
+
+const mockExperiencePlatformConnectorExtenion: ExperiencePlatformConnectorExtension = {
     version: "1.2.3",
 };
 
@@ -522,6 +527,7 @@ export {
     mockChangedProducts,
     mockDataServicesExtension,
     mockEvent,
+    mockExperiencePlatformConnectorExtenion,
     mockExtension,
     mockOrder,
     mockPage,

--- a/packages/storefront-events-collector/tests/utils/setup.ts
+++ b/packages/storefront-events-collector/tests/utils/setup.ts
@@ -3,6 +3,7 @@ import mse from "@adobe/magento-storefront-events-sdk";
 import {
     mockCategory,
     mockDataServicesExtension,
+    mockExperiencePlatformConnectorExtenion,
     mockExtension,
     mockOrder,
     mockPage,
@@ -24,6 +25,7 @@ window.magentoStorefrontEvents = mse;
 mse.context.setCategory(mockCategory);
 mse.context.setMagentoExtension(mockExtension);
 mse.context.setDataServicesExtension(mockDataServicesExtension);
+mse.context.setExperiencePlatformConnectorExtension(mockExperiencePlatformConnectorExtenion);
 mse.context.setRecommendationsExtension(mockRecommendationsExtension);
 mse.context.setSearchExtension(mockSearchExtension);
 mse.context.setOrder(mockOrder);

--- a/packages/storefront-events-sdk/README.md
+++ b/packages/storefront-events-sdk/README.md
@@ -185,6 +185,14 @@ Sets the `DataServicesExtension` context. Includes Data Services extension versi
 
 -   [context schema definition](https://github.com/adobe/commerce-events/tree/main/packages/commerce-events-sdk/src/types/schemas/dataServicesExtension.ts)
 
+#### `setExperiencePlatformConnectorExtension`
+
+```javascript
+mse.context.setExperiencePlatformConnectorExtension(experiencePlatformConnectorExtensionCtx);
+```
+
+Sets the `ExperiencePlatformConnectorExtension` context. Includes Experience Platform Connector extension version.
+
 #### `setOrder`
 
 ```javascript

--- a/packages/storefront-events-sdk/src/ContextManager.ts
+++ b/packages/storefront-events-sdk/src/ContextManager.ts
@@ -8,6 +8,7 @@ import {
     CustomUrl,
     Debug,
     EventForwarding,
+    ExperiencePlatformConnectorExtension,
     MagentoExtension,
     Order,
     Page,
@@ -71,6 +72,19 @@ export default class ContextManager extends Base {
 
     setEventForwarding(context: EventForwarding): void {
         this.setContext<EventForwarding>(contexts.EVENT_FORWARDING_CONTEXT, context);
+    }
+
+    getExperiencePlatformConnectorExtension(): ExperiencePlatformConnectorExtension {
+        return this.getContext<ExperiencePlatformConnectorExtension>(
+            contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT,
+        );
+    }
+
+    setExperiencePlatformConnectorExtension(context: ExperiencePlatformConnectorExtension): void {
+        this.setContext<ExperiencePlatformConnectorExtension>(
+            contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT,
+            context,
+        );
     }
 
     getCustomUrl(): CustomUrl {

--- a/packages/storefront-events-sdk/src/contexts.ts
+++ b/packages/storefront-events-sdk/src/contexts.ts
@@ -7,6 +7,7 @@ const contexts = {
     DATA_SERVICES_EXTENSION_CONTEXT: "dataServicesExtensionContext",
     DEBUG_CONTEXT: "debugContext",
     EVENT_FORWARDING_CONTEXT: "eventForwardingContext",
+    EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT: "experiencePlatformConnectorExtensionContext",
     MAGENTO_EXTENSION_CONTEXT: "magentoExtensionContext",
     ORDER_CONTEXT: "orderContext",
     PAGE_CONTEXT: "pageContext",

--- a/packages/storefront-events-sdk/src/types/contexts.ts
+++ b/packages/storefront-events-sdk/src/types/contexts.ts
@@ -8,6 +8,7 @@ import {
     DataServicesExtension,
     Debug,
     EventForwarding,
+    ExperiencePlatformConnectorExtension,
     MagentoExtension,
     Order,
     Page,
@@ -31,6 +32,7 @@ export type ContextName =
     | typeof contexts.DATA_SERVICES_EXTENSION_CONTEXT
     | typeof contexts.DEBUG_CONTEXT
     | typeof contexts.EVENT_FORWARDING_CONTEXT
+    | typeof contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT
     | typeof contexts.MAGENTO_EXTENSION_CONTEXT
     | typeof contexts.ORDER_CONTEXT
     | typeof contexts.PAGE_CONTEXT
@@ -54,6 +56,7 @@ export type Context = {
     [contexts.DATA_SERVICES_EXTENSION_CONTEXT]?: DataServicesExtension;
     [contexts.DEBUG_CONTEXT]?: Debug;
     [contexts.EVENT_FORWARDING_CONTEXT]?: EventForwarding;
+    [contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT]?: ExperiencePlatformConnectorExtension;
     [contexts.MAGENTO_EXTENSION_CONTEXT]: MagentoExtension;
     [contexts.ORDER_CONTEXT]: Order;
     [contexts.PAGE_CONTEXT]: Page;

--- a/packages/storefront-events-sdk/src/types/schemas/experiencePlatformConnectorExtension.ts
+++ b/packages/storefront-events-sdk/src/types/schemas/experiencePlatformConnectorExtension.ts
@@ -1,0 +1,4 @@
+/* information about the EPC PHP extension */
+export type ExperiencePlatformConnectorExtension = {
+    version: string;
+};

--- a/packages/storefront-events-sdk/src/types/schemas/index.ts
+++ b/packages/storefront-events-sdk/src/types/schemas/index.ts
@@ -6,6 +6,7 @@ export * from "./changedProducts";
 export * from "./customUrl";
 export * from "./debug";
 export * from "./eventForwarding";
+export * from "./experiencePlatformConnectorExtension";
 export * from "./magentoExtension";
 export * from "./dataServicesExtension";
 export * from "./recommendationsExtension";


### PR DESCRIPTION
@grahamcrackers i'm missing something here - i'm unable to run the example code successfully bc it's not finding my new context on the `mse` object - but it should be there - i'm afraid it's another old sdk and new schema mismatch but... can you look for 30 seconds and see what i'm doing wrong? if not too obvious i'll keep debugging