### PR TITLE
:bug: fix qa build for packages

### DIFF
--- a/.github/workflows/storefront-merge-to-main.yml
+++ b/.github/workflows/storefront-merge-to-main.yml
@@ -34,7 +34,7 @@ jobs:
               run: yarn install --frozen-lockfile
 
             - name: build
-              run: yarn build:qa
+              run: yarn build:qa --filter="@adobe/*"
 
             - name: release storefront sdk
               working-directory: ./packages/storefront-events-sdk

--- a/packages/commerce-events-collectors/rollup.config.js
+++ b/packages/commerce-events-collectors/rollup.config.js
@@ -12,6 +12,7 @@ import pkg from "./package.json";
 /* planning on moving this to it's own local package but for now i'm just hashing out the beginnings  */
 /******************************************************************************************************/
 const isProduction = process.env.NODE_ENV === "production";
+const isTesting = process.env.NODE_ENV === "testing";
 
 // creates a full build that bundles all modules needed
 const bundle = (config) => ({
@@ -97,7 +98,7 @@ export default [
         },
         plugins: [
             dts(),
-            !isProduction &&
+            !isProduction && !isTesting &&
                 serve({
                     contentBase: "dist",
                     port: 8083,

--- a/packages/commerce-events-sdk/rollup.config.js
+++ b/packages/commerce-events-sdk/rollup.config.js
@@ -12,6 +12,7 @@ import pkg from "./package.json";
 /* planning on moving this to it's own local package but for now i'm just hashing out the beginnings  */
 /******************************************************************************************************/
 const isProduction = process.env.NODE_ENV === "production";
+const isTesting = process.env.NODE_ENV === "testing";
 
 // creates a full build that bundles all modules needed
 const bundle = (config) => ({
@@ -98,7 +99,7 @@ export default [
         },
         plugins: [
             dts(),
-            !isProduction &&
+            !isProduction && !isTesting &&
                 serve({
                     contentBase: "dist",
                     port: 8082,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The QA build was handing since the build script was also trying to serve the files in the middle of the build. I changed workflow to filter by `@adobe` packages and added a check for the `NODE_ENV=testing`, which was the cause of the build hanging up


## Motivation and Context

Fixes QA builds

## How Has This Been Tested?

I've run it locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
