### PR TITLE
Dint 526 Add openCart event and AEP handler for it

### DIFF
--- a/packages/commerce-events-collectors/README.md
+++ b/packages/commerce-events-collectors/README.md
@@ -44,6 +44,7 @@ The collector listens for the following events.
 -   `productPageView`
 -   `shoppingCartView`
 -   `initiateCheckout`
+-   `openCart`
 -   `placeOrder`
 -   `abandonCart`
 -   `recsItemAddToCartClick`
@@ -78,6 +79,10 @@ The handlers forward events to two edges:
     `createAccount`
 
     `editAccount`
+
+    `openCart`
+
+    `removeFromCart`
 
     `signIn`
 

--- a/packages/commerce-events-collectors/src/events.ts
+++ b/packages/commerce-events-collectors/src/events.ts
@@ -9,6 +9,7 @@ import {
     editAccountHandlerAEP,
     initiateCheckoutHandler,
     initiateCheckoutHandlerAEP,
+    openCartHandlerAEP,
     pageViewHandler,
     pageViewHandlerAEP,
     placeOrderHandler,
@@ -66,6 +67,7 @@ const handleAepPageView = handleIf(isAep, pageViewHandlerAEP);
 // cart
 const handleSnowplowInitiateCheckout = handleIf(isCommerce, initiateCheckoutHandler);
 const handleAepInitiateCheckout = handleIf(isAep, initiateCheckoutHandlerAEP);
+const handleAepOpenCart = handleIf(isAep, openCartHandlerAEP);
 
 // product
 const handleSnowplowAddToCart = handleIf(isCommerce, addToCartHandler);
@@ -129,6 +131,7 @@ const subscribeToEvents = (): void => {
         mse.subscribe.createAccount(handleAepCreateAccount);
         mse.subscribe.editAccount(handleAepEditAccount);
         mse.subscribe.initiateCheckout(handleAepInitiateCheckout);
+        mse.subscribe.openCart(handleAepOpenCart);
         mse.subscribe.pageView(handleAepPageView);
         mse.subscribe.placeOrder(handleAepPlaceOrder);
         mse.subscribe.productPageView(handleAepProductView);
@@ -178,6 +181,7 @@ const unsubscribeFromEvents = (): void => {
         mse.unsubscribe.custom(handleAepCustom);
         mse.unsubscribe.editAccount(handleAepEditAccount);
         mse.unsubscribe.initiateCheckout(handleAepInitiateCheckout);
+        mse.unsubscribe.openCart(handleAepOpenCart);
         mse.unsubscribe.pageView(handleAepPageView);
         mse.unsubscribe.placeOrder(handleAepPlaceOrder);
         mse.unsubscribe.productPageView(handleAepProductView);

--- a/packages/commerce-events-collectors/src/handlers/shoppingCart/index.ts
+++ b/packages/commerce-events-collectors/src/handlers/shoppingCart/index.ts
@@ -1,4 +1,5 @@
 export { default as initiateCheckoutHandler } from "./initiateCheckout";
 export { default as initiateCheckoutHandlerAEP } from "./initiateCheckoutAEP";
+export { default as openCartHandlerAEP } from "./openCartAEP";
 export { default as shoppingCartViewHandler } from "./view";
 export { default as shoppingCartViewHandlerAEP } from "./viewAEP";

--- a/packages/commerce-events-collectors/src/handlers/shoppingCart/openCartAEP.ts
+++ b/packages/commerce-events-collectors/src/handlers/shoppingCart/openCartAEP.ts
@@ -1,0 +1,38 @@
+import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
+
+import { sendEvent } from "../../alloy";
+import { BeaconSchema } from "../../types/aep";
+import { createProductListItems } from "../../utils/aep/productListItems";
+
+const XDM_EVENT_TYPE = "commerce.productListOpens";
+
+const handler = async (event: Event): Promise<void> => {
+    const { changedProductsContext, shoppingCartContext, debugContext, storefrontInstanceContext, customContext } = event.eventInfo;
+    let payload: BeaconSchema;
+    if (customContext && Object.keys(customContext as BeaconSchema).length !== 0) {
+        // override payload on custom context
+        payload = customContext as BeaconSchema;
+    } else {
+        payload = {
+            commerce: {
+                cart: {
+                    cartID: shoppingCartContext.id,
+                },
+            },
+            productListItems: createProductListItems(changedProductsContext, storefrontInstanceContext),
+        };
+    }
+
+    payload.commerce = payload.commerce || {};
+
+    payload.commerce.productListOpens = {
+        value: 1,
+    };
+
+    payload._id = debugContext?.eventId;
+    payload.eventType = XDM_EVENT_TYPE;
+
+    sendEvent(payload);
+};
+
+export default handler;

--- a/packages/commerce-events-collectors/src/types/aep/commerce.ts
+++ b/packages/commerce-events-collectors/src/types/aep/commerce.ts
@@ -1,6 +1,7 @@
 /* top level object for all transaction events */
 export type Commerce = {
     productListAdds?: ProductListAdds;
+    productListOpens?: ProductListOpens;
     productListRemovals?: ProductListRemovals;
     productListViews?: ProductListViews;
     cart?: Cart;
@@ -55,6 +56,14 @@ export type Checkout = {
  * to a shopping cart.
  */
 export type ProductListAdds = {
+    id?: string;
+    value: number;
+};
+
+/**
+ * Addition of a product to an empty product list
+ */
+ export type ProductListOpens = {
     id?: string;
     value: number;
 };

--- a/packages/commerce-events-collectors/tests/handlers/shoppingCart/openCartAEP.test.ts
+++ b/packages/commerce-events-collectors/tests/handlers/shoppingCart/openCartAEP.test.ts
@@ -1,0 +1,48 @@
+jest.mock("../../../src/alloy");
+import { sendEvent } from "../../../src/alloy";
+import { openCartHandlerAEP } from "../../../src/handlers";
+import { mockEvent } from "../../utils/mocks";
+
+const AEPevent = { ...mockEvent };
+delete AEPevent.eventInfo.customContext;
+
+test("correctly structures AEP event and calls alloy.sendEvent", () => {
+    openCartHandlerAEP(mockEvent);
+
+    expect(sendEvent).toHaveBeenCalledTimes(1);
+
+    expect(sendEvent).toHaveBeenCalledWith({
+        commerce: {
+            cart: {
+                cartID: "111111"
+            },
+            productListOpens: {
+                value: 1,
+            },
+        },
+        productListItems: [
+            {
+                SKU: "ts001",
+                name: "T-Shirt",
+                quantity: 1,
+                priceTotal: 20,
+                productImageUrl: undefined,
+                currencyCode: "USD",
+                discountAmount: 0,
+                selectedOptions: [],
+            },
+            {
+                SKU: "h001",
+                name: "Hoodie",
+                quantity: 1,
+                priceTotal: 50,
+                productImageUrl: undefined,
+                currencyCode: "USD",
+                discountAmount: 0,
+                selectedOptions: [],
+            },
+        ],
+        _id: undefined,
+        eventType: "commerce.productListOpens",
+    });
+});

--- a/packages/commerce-events-sdk/README.md
+++ b/packages/commerce-events-sdk/README.md
@@ -386,6 +386,10 @@ mse.publish.initiateCheckout(ctx);
 ```
 
 ```javascript
+mse.publish.openCart(ctx);
+```
+
+```javascript
 mse.publish.pageActivitySummary(ctx);
 ```
 
@@ -496,6 +500,7 @@ mse.subscribe.editAccount(handler, options);
 mse.subscribe.dataLayerChange(handler, options);
 mse.subscribe.dataLayerEvent(handler, options);
 mse.subscribe.initiateCheckout(handler, options);
+mse.subscribe.openCart(handler, options);
 mse.subscribe.pageActivitySummary(handler, options);
 mse.subscribe.pageView(handler, options);
 mse.subscribe.placeOrder(handler, options);
@@ -534,6 +539,7 @@ mse.unsubscribe.editAccount(handler);
 mse.unsubscribe.dataLayerChange(handler);
 mse.unsubscribe.dataLayerEvent(handler);
 mse.unsubscribe.initiateCheckout(handler);
+mse.unsubscribe.openCart(handler);
 mse.unsubscribe.pageActivitySummary(handler);
 mse.unsubscribe.pageView(handler);
 mse.unsubscribe.placeOrder(handler);

--- a/packages/commerce-events-sdk/src/PublishManager.ts
+++ b/packages/commerce-events-sdk/src/PublishManager.ts
@@ -35,6 +35,10 @@ export default class PublishManager extends Base {
         this.pushEvent(events.INITIATE_CHECKOUT, { customContext: context });
     }
 
+    openCart(context?: CustomContext): void {
+        this.pushEvent(events.OPEN_CART, { customContext: context });
+    }
+
     pageActivitySummary(context?: CustomContext): void {
         this.pushEvent(events.PAGE_ACTIVITY_SUMMARY, {
             customContext: context,

--- a/packages/commerce-events-sdk/src/SubscribeManager.ts
+++ b/packages/commerce-events-sdk/src/SubscribeManager.ts
@@ -35,6 +35,10 @@ export default class SubscribeManager extends Base {
         this.addEventListener(events.INITIATE_CHECKOUT, handler, options);
     }
 
+    openCart(handler: EventHandler, options?: ListenerOptions): void {
+        this.addEventListener(events.OPEN_CART, handler, options);
+    }
+
     pageActivitySummary(handler: EventHandler, options?: ListenerOptions): void {
         this.addEventListener(events.PAGE_ACTIVITY_SUMMARY, handler, options);
     }

--- a/packages/commerce-events-sdk/src/UnsubscribeManager.ts
+++ b/packages/commerce-events-sdk/src/UnsubscribeManager.ts
@@ -35,6 +35,10 @@ export default class UnsubscribeManager extends Base {
         this.removeEventListener(events.INITIATE_CHECKOUT, handler);
     }
 
+    openCart(handler: EventHandler): void {
+        this.removeEventListener(events.OPEN_CART, handler);
+    }
+
     pageActivitySummary(handler: EventHandler): void {
         this.removeEventListener(events.PAGE_ACTIVITY_SUMMARY, handler);
     }

--- a/packages/commerce-events-sdk/src/events.ts
+++ b/packages/commerce-events-sdk/src/events.ts
@@ -8,6 +8,7 @@ const events = {
     DATA_LAYER_EVENT: "adobeDataLayer:event",
     EDIT_ACCOUNT: "edit-account",
     INITIATE_CHECKOUT: "initiate-checkout",
+    OPEN_CART: "open-cart",
     PAGE_ACTIVITY_SUMMARY: "page-activity-summary",
     PAGE_VIEW: "page-view",
     PLACE_ORDER: "place-order",

--- a/packages/commerce-events-sdk/src/types/events.ts
+++ b/packages/commerce-events-sdk/src/types/events.ts
@@ -11,6 +11,7 @@ export type EventName =
     | typeof events.DATA_LAYER_EVENT
     | typeof events.EDIT_ACCOUNT
     | typeof events.INITIATE_CHECKOUT
+    | typeof events.OPEN_CART
     | typeof events.PAGE_ACTIVITY_SUMMARY
     | typeof events.PAGE_VIEW
     | typeof events.PLACE_ORDER

--- a/packages/storefront-events-collector/README.md
+++ b/packages/storefront-events-collector/README.md
@@ -44,6 +44,7 @@ The collector listens for the following events.
 -   `productPageView`
 -   `shoppingCartView`
 -   `initiateCheckout`
+-   `openCart`
 -   `placeOrder`
 -   `recsItemAddToCartClick`
 -   `recsItemClick`
@@ -77,6 +78,10 @@ The handlers forward events to two edges:
     `createAccount`
 
     `editAccount`
+
+    `openCart`
+
+    `removeFromCart`
 
     `signIn`
 

--- a/packages/storefront-events-collector/src/events.ts
+++ b/packages/storefront-events-collector/src/events.ts
@@ -9,6 +9,7 @@ import {
     editAccountHandlerAEP,
     initiateCheckoutHandler,
     initiateCheckoutHandlerAEP,
+    openCartHandlerAEP,
     pageViewHandler,
     pageViewHandlerAEP,
     placeOrderHandler,
@@ -66,6 +67,7 @@ const handleAepPageView = handleIf(isAep, pageViewHandlerAEP);
 // cart
 const handleSnowplowInitiateCheckout = handleIf(isCommerce, initiateCheckoutHandler);
 const handleAepInitiateCheckout = handleIf(isAep, initiateCheckoutHandlerAEP);
+const handleAepOpenCart = handleIf(isAep, openCartHandlerAEP);
 
 // product
 const handleSnowplowAddToCart = handleIf(isCommerce, addToCartHandler);
@@ -129,6 +131,7 @@ const subscribeToEvents = (): void => {
         mse.subscribe.createAccount(handleAepCreateAccount);
         mse.subscribe.editAccount(handleAepEditAccount);
         mse.subscribe.initiateCheckout(handleAepInitiateCheckout);
+        mse.subscribe.openCart(handleAepOpenCart);
         mse.subscribe.pageView(handleAepPageView);
         mse.subscribe.placeOrder(handleAepPlaceOrder);
         mse.subscribe.productPageView(handleAepProductView);
@@ -178,6 +181,7 @@ const unsubscribeFromEvents = (): void => {
         mse.unsubscribe.custom(handleAepCustom);
         mse.unsubscribe.editAccount(handleAepEditAccount);
         mse.unsubscribe.initiateCheckout(handleAepInitiateCheckout);
+        mse.unsubscribe.openCart(handleAepOpenCart);
         mse.unsubscribe.pageView(handleAepPageView);
         mse.unsubscribe.placeOrder(handleAepPlaceOrder);
         mse.unsubscribe.productPageView(handleAepProductView);

--- a/packages/storefront-events-collector/src/handlers/shoppingCart/index.ts
+++ b/packages/storefront-events-collector/src/handlers/shoppingCart/index.ts
@@ -1,4 +1,5 @@
 export { default as initiateCheckoutHandler } from "./initiateCheckout";
 export { default as initiateCheckoutHandlerAEP } from "./initiateCheckoutAEP";
+export { default as openCartHandlerAEP } from "./openCartAEP";
 export { default as shoppingCartViewHandler } from "./view";
 export { default as shoppingCartViewHandlerAEP } from "./viewAEP";

--- a/packages/storefront-events-collector/src/handlers/shoppingCart/openCartAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/shoppingCart/openCartAEP.ts
@@ -1,0 +1,38 @@
+import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
+
+import { sendEvent } from "../../alloy";
+import { BeaconSchema } from "../../types/aep";
+import { createProductListItems } from "../../utils/aep/productListItems";
+
+const XDM_EVENT_TYPE = "commerce.productListOpens";
+
+const handler = async (event: Event): Promise<void> => {
+    const { changedProductsContext, shoppingCartContext, debugContext, storefrontInstanceContext, customContext } = event.eventInfo;
+    let payload: BeaconSchema;
+    if (customContext && Object.keys(customContext as BeaconSchema).length !== 0) {
+        // override payload on custom context
+        payload = customContext as BeaconSchema;
+    } else {
+        payload = {
+            commerce: {
+                cart: {
+                    cartID: shoppingCartContext.id,
+                },
+            },
+            productListItems: createProductListItems(changedProductsContext, storefrontInstanceContext),
+        };
+    }
+
+    payload.commerce = payload.commerce || {};
+
+    payload.commerce.productListOpens = {
+        value: 1,
+    };
+
+    payload._id = debugContext?.eventId;
+    payload.eventType = XDM_EVENT_TYPE;
+
+    sendEvent(payload);
+};
+
+export default handler;

--- a/packages/storefront-events-collector/src/types/aep/commerce.ts
+++ b/packages/storefront-events-collector/src/types/aep/commerce.ts
@@ -1,6 +1,7 @@
 /* top level object for all transaction events */
 export type Commerce = {
     productListAdds?: ProductListAdds;
+    productListOpens?: ProductListOpens;
     productListRemovals?: ProductListRemovals;
     productListViews?: ProductListViews;
     cart?: Cart;
@@ -55,6 +56,14 @@ export type Checkout = {
  * to a shopping cart.
  */
 export type ProductListAdds = {
+    id?: string;
+    value: number;
+};
+
+/**
+ * Addition of a product to an empty product list
+ */
+ export type ProductListOpens = {
     id?: string;
     value: number;
 };

--- a/packages/storefront-events-collector/tests/handlers/shoppingCart/openCartAEP.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/shoppingCart/openCartAEP.test.ts
@@ -1,0 +1,48 @@
+jest.mock("../../../src/alloy");
+import { sendEvent } from "../../../src/alloy";
+import { openCartHandlerAEP } from "../../../src/handlers";
+import { mockEvent } from "../../utils/mocks";
+
+const AEPevent = { ...mockEvent };
+delete AEPevent.eventInfo.customContext;
+
+test("correctly structures AEP event and calls alloy.sendEvent", () => {
+    openCartHandlerAEP(mockEvent);
+
+    expect(sendEvent).toHaveBeenCalledTimes(1);
+
+    expect(sendEvent).toHaveBeenCalledWith({
+        commerce: {
+            cart: {
+                cartID: "111111"
+            },
+            productListOpens: {
+                value: 1,
+            },
+        },
+        productListItems: [
+            {
+                SKU: "ts001",
+                name: "T-Shirt",
+                quantity: 1,
+                priceTotal: 20,
+                productImageUrl: undefined,
+                currencyCode: "USD",
+                discountAmount: 0,
+                selectedOptions: [],
+            },
+            {
+                SKU: "h001",
+                name: "Hoodie",
+                quantity: 1,
+                priceTotal: 50,
+                productImageUrl: undefined,
+                currencyCode: "USD",
+                discountAmount: 0,
+                selectedOptions: [],
+            },
+        ],
+        _id: undefined,
+        eventType: "commerce.productListOpens",
+    });
+});

--- a/packages/storefront-events-sdk/README.md
+++ b/packages/storefront-events-sdk/README.md
@@ -382,6 +382,10 @@ mse.publish.initiateCheckout(ctx);
 ```
 
 ```javascript
+mse.publish.openCart(ctx);
+```
+
+```javascript
 mse.publish.pageActivitySummary(ctx);
 ```
 
@@ -491,6 +495,7 @@ mse.subscribe.editAccount(handler, options);
 mse.subscribe.dataLayerChange(handler, options);
 mse.subscribe.dataLayerEvent(handler, options);
 mse.subscribe.initiateCheckout(handler, options);
+mse.subscribe.openCart(handler, options);
 mse.subscribe.pageActivitySummary(handler, options);
 mse.subscribe.pageView(handler, options);
 mse.subscribe.placeOrder(handler, options);
@@ -528,6 +533,7 @@ mse.unsubscribe.editAccount(handler);
 mse.unsubscribe.dataLayerChange(handler);
 mse.unsubscribe.dataLayerEvent(handler);
 mse.unsubscribe.initiateCheckout(handler);
+mse.unsubscribe.openCart(handler);
 mse.unsubscribe.pageActivitySummary(handler);
 mse.unsubscribe.pageView(handler);
 mse.unsubscribe.placeOrder(handler);

--- a/packages/storefront-events-sdk/src/PublishManager.ts
+++ b/packages/storefront-events-sdk/src/PublishManager.ts
@@ -35,6 +35,10 @@ export default class PublishManager extends Base {
         this.pushEvent(events.INITIATE_CHECKOUT, { customContext: context });
     }
 
+    openCart(context?: CustomContext): void {
+        this.pushEvent(events.OPEN_CART, { customContext: context });
+    }
+
     pageActivitySummary(context?: CustomContext): void {
         this.pushEvent(events.PAGE_ACTIVITY_SUMMARY, {
             customContext: context,

--- a/packages/storefront-events-sdk/src/SubscribeManager.ts
+++ b/packages/storefront-events-sdk/src/SubscribeManager.ts
@@ -35,6 +35,10 @@ export default class SubscribeManager extends Base {
         this.addEventListener(events.INITIATE_CHECKOUT, handler, options);
     }
 
+    openCart(handler: EventHandler, options?: ListenerOptions): void {
+        this.addEventListener(events.OPEN_CART, handler, options);
+    }
+
     pageActivitySummary(handler: EventHandler, options?: ListenerOptions): void {
         this.addEventListener(events.PAGE_ACTIVITY_SUMMARY, handler, options);
     }

--- a/packages/storefront-events-sdk/src/UnsubscribeManager.ts
+++ b/packages/storefront-events-sdk/src/UnsubscribeManager.ts
@@ -35,6 +35,10 @@ export default class UnsubscribeManager extends Base {
         this.removeEventListener(events.INITIATE_CHECKOUT, handler);
     }
 
+    openCart(handler: EventHandler): void {
+        this.removeEventListener(events.OPEN_CART, handler);
+    }
+
     pageActivitySummary(handler: EventHandler): void {
         this.removeEventListener(events.PAGE_ACTIVITY_SUMMARY, handler);
     }

--- a/packages/storefront-events-sdk/src/events.ts
+++ b/packages/storefront-events-sdk/src/events.ts
@@ -8,6 +8,7 @@ const events = {
     DATA_LAYER_EVENT: "adobeDataLayer:event",
     EDIT_ACCOUNT: "edit-account",
     INITIATE_CHECKOUT: "initiate-checkout",
+    OPEN_CART: "open-cart",
     PAGE_ACTIVITY_SUMMARY: "page-activity-summary",
     PAGE_VIEW: "page-view",
     PLACE_ORDER: "place-order",

--- a/packages/storefront-events-sdk/src/types/events.ts
+++ b/packages/storefront-events-sdk/src/types/events.ts
@@ -11,6 +11,7 @@ export type EventName =
     | typeof events.DATA_LAYER_EVENT
     | typeof events.EDIT_ACCOUNT
     | typeof events.INITIATE_CHECKOUT
+    | typeof events.OPEN_CART
     | typeof events.PAGE_ACTIVITY_SUMMARY
     | typeof events.PAGE_VIEW
     | typeof events.PLACE_ORDER


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding new event openCart for purposes of handling when a product is added to empty cart.
Currently event is only handled and sent to AEP.
Payload sent to AEP is in fashion of commerce schema with "productListOpens" as the event and value set to 1. 
Product list sent in event payload to AEP is the list of products that have been added.

## Related Issue

https://jira.corp.adobe.com/browse/DINT-526

## Motivation and Context

To clarify when a cart is being "initialized" for reporting purposes.

## How Has This Been Tested?

Using the branch seen in this PR https://git.corp.adobe.com/magento-datalake/magento2-snowplow-js/pull/218
Ensure cart is empty.  Add a product, or combo product.  Verify that the open cart event is triggered and sent to AEP using the AEP debugger.  Verify that the product list in the event payload has the product or products with their correct quantity.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
