### PR TITLE
SEG-122: [segment-collector] Retrieve RTCDP Segment membership info f…

### DIFF
--- a/packages/commerce-events-collector-segments/src/aep/types/alloy.types.ts
+++ b/packages/commerce-events-collector-segments/src/aep/types/alloy.types.ts
@@ -41,7 +41,9 @@ export type consentOptions = {
 export type AlloyInstance = (
     command: CommandType,
     options?: ConfigOptions | XDM<BeaconSchema> | consentOptions,
-) => Promise<void | AlloySendEventResponse | AlloyIdentity>;
+) => Promise<void | AlloyReturnData>;
+
+export type AlloyReturnData = AlloyIdentity & AlloyIdentity;
 
 export type AlloyIdentity = {
     identity?: {

--- a/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getECID.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getECID.ts
@@ -1,5 +1,5 @@
 // Get ECID from alloy
-import { AlloyIdentity, AlloySendEventResponse } from "../../aep/types";
+import { AlloyReturnData, AlloyIdentity } from "../../aep/types";
 
 const getECID = (): Promise<string | void> => {
     return new Promise((resolve, reject): string | void => {
@@ -9,7 +9,7 @@ const getECID = (): Promise<string | void> => {
             if (window.hasOwnProperty("alloy")) {
                 window
                     .alloy("getIdentity")
-                    .then((result: void | AlloySendEventResponse | AlloyIdentity) => {
+                    .then((result: void | AlloyReturnData) => {
                         const { identity } = result as AlloyIdentity;
                         console.log("Alloy fetched identity.");
                         resolve(identity?.ECID || "");

--- a/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getSegmentIds.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/alloyIntegration/getSegmentIds.ts
@@ -1,11 +1,11 @@
-import { AlloyIdentity, AlloySendEventResponse } from "../../aep/types";
+import { AlloyReturnData, AlloySendEventResponse } from "../../aep/types";
 
 const getSegmentIds = (): Promise<string | void> => {
     return new Promise((resolve, reject): string | void => {
         if (window.hasOwnProperty("alloy")) {
             window
                 .alloy("sendEvent")
-                .then((result: void | AlloySendEventResponse | AlloyIdentity) => {
+                .then((result: void | AlloyReturnData) => {
                     const { destinations } = result as AlloySendEventResponse;
                     const segments = destinations?.map(({ segments }) => segments.map(({ id }) => id)).join(",") || "";
                     resolve(segments);

--- a/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/index.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/index.ts
@@ -1,1 +1,4 @@
-export { default as setAdobeCommerceSegmentCookies } from "./setAdobeCommerceSegmentCookies";
+export {
+    default as setAdobeCommerceAEPSegmentCookies,
+    clearAdobeCommerceAEPSegmentCookies,
+} from "./setAdobeCommerceSegmentCookies";

--- a/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/setAdobeCommerceSegmentCookies.ts
+++ b/packages/commerce-events-collector-segments/src/handlers/browserCookieIntegration/setAdobeCommerceSegmentCookies.ts
@@ -5,6 +5,15 @@
  * @link https://github.com/magento-commerce/segments-service/blob/poc/Segment/Model/SegmentResolver.php#L12
  */
 const ADOBE_COMMERCE_SHOPPER_SEGMENT = "adobe_segment";
+const ADOBE_COMMERCE_AEP_SEGMENT_MEMBERSHIP_COOKIE_NAME = "aep-segments-membership";
+
+/**
+ * Clear the browsers cookies set for Adobe Commerce AEP Segments
+ */
+export const clearAdobeCommerceAEPSegmentCookies = () => {
+    document.cookie = `${ADOBE_COMMERCE_SHOPPER_SEGMENT}=; expires=Fri, 31 Dec 1999 23:59:59 GMT;`;
+    document.cookie = `${ADOBE_COMMERCE_AEP_SEGMENT_MEMBERSHIP_COOKIE_NAME}=; expires=Fri, 31 Dec 1999 23:59:59 GMT;`;
+};
 
 /**
  * Set the browser cookies with the returned segmentMembershipIds from the proxy service
@@ -13,9 +22,10 @@ const ADOBE_COMMERCE_SHOPPER_SEGMENT = "adobe_segment";
  *
  * @param userSegmentIds comma delimited string of `segmentMembershipIds` that is returned from the proxy service
  */
-const setAdobeCommerceSegmentCookies = (userSegmentIds = "") => {
+const setAdobeCommerceAEPSegmentCookies = (userSegmentIds = "") => {
     //again, note that no expiration is set, so this will be a session cookie
     document.cookie = `${ADOBE_COMMERCE_SHOPPER_SEGMENT}=${userSegmentIds}`;
+    document.cookie = `${ADOBE_COMMERCE_AEP_SEGMENT_MEMBERSHIP_COOKIE_NAME}=${userSegmentIds}`;
 };
 
-export default setAdobeCommerceSegmentCookies;
+export default setAdobeCommerceAEPSegmentCookies;

--- a/packages/commerce-events-collector-segments/src/index.ts
+++ b/packages/commerce-events-collector-segments/src/index.ts
@@ -1,4 +1,7 @@
-import { setAdobeCommerceSegmentCookies } from "./handlers/browserCookieIntegration";
+import {
+    setAdobeCommerceAEPSegmentCookies,
+    clearAdobeCommerceAEPSegmentCookies,
+} from "./handlers/browserCookieIntegration";
 import { getSegmentIds } from "./handlers/alloyIntegration";
 
 const GET_SEGMENT_IDS_FROM_ALLOY_INTERVAL = 60000; //1 minute
@@ -8,6 +11,9 @@ let setSegmentIdsInterval: ReturnType<typeof setInterval> | undefined = undefine
 let setSegmentIdsCounter = 0;
 
 const initialize = async () => {
+    // need to clear any existing cookies just to avoid any conflicts
+    clearAdobeCommerceAEPSegmentCookies();
+
     try {
         // need to call proxy service every set amount of time and retrieve updated segment information
         setSegmentIdsInterval = setInterval(setCookieWithSegmentIds, GET_SEGMENT_IDS_FROM_ALLOY_INTERVAL);
@@ -25,7 +31,7 @@ const setCookieWithSegmentIds = async () => {
     } else {
         setSegmentIdsCounter++;
         const userSegmentIds = (await getSegmentIds()) || "";
-        setAdobeCommerceSegmentCookies(userSegmentIds);
+        setAdobeCommerceAEPSegmentCookies(userSegmentIds);
     }
 };
 

--- a/packages/commerce-events-collector-segments/tests/utils/setup.ts
+++ b/packages/commerce-events-collector-segments/tests/utils/setup.ts
@@ -1,3 +1,3 @@
-export { setAdobeCommerceSegmentCookies } from "../../src/handlers/browserCookieIntegration";
+export { setAdobeCommerceAEPSegmentCookies } from "../../src/handlers/browserCookieIntegration";
 export { getECID } from "../../src/handlers/alloyIntegration";
 export { getSegmentIds } from "../../src/handlers/alloyIntegration";


### PR DESCRIPTION
## Description

- Updated cookie name that we are saving to
- cleaned up typing for return object we get back from Alloy

## Related Issue

[segment-collector: SEG-122](https://jira.corp.adobe.com/browse/SEG-122)

## Motivation and Context

Retrieve RTCDP Segment membership info

## How Has This Been Tested?

Locally via unit tests, and deployed via unkpg

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have read the **CONTRIBUTING** document.
-   [X] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
