### PR TITLE
release 1.1.17

### DIFF
--- a/packages/storefront-events-collector/package.json
+++ b/packages/storefront-events-collector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/magento-storefront-event-collector",
-    "version": "1.1.16",
+    "version": "1.1.17",
     "description": "Event Collectors for Adobe Commerce storefronts",
     "license": "MIT",
     "main": "./dist/index.js",

--- a/packages/storefront-events-sdk/package.json
+++ b/packages/storefront-events-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/magento-storefront-events-sdk",
-    "version": "1.1.16",
+    "version": "1.1.17",
     "description": "SDK for working with events on an Adobe Commerce storefront",
     "license": "MIT",
     "main": "./dist/index.js",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Release 1.1.17 for `@adobe/magento-storefront-events-sdk` and `@adobe/magento-storefront-event-collector`.

## Related Issue

Changes include multiple tickets:
[DINT-616](https://jira.corp.adobe.com/browse/DINT-616): Adding fields for AEPContext
[DINT-590](https://jira.corp.adobe.com/browse/DINT-590): Adding Image URL's
[DINT-522](https://jira.corp.adobe.com/browse/DINT-522) & [DINT-524](https://jira.corp.adobe.com/browse/DINT-524) & [DINT-526](https://jira.corp.adobe.com/browse/DINT-526): Adding Cart Events
[DINT-531](https://jira.corp.adobe.com/browse/DINT-531): Snowplow addToCart event
[DINT-651](https://jira.corp.adobe.com/browse/DINT-651): Configurable Data Layer for SDK
[DINT-641](https://jira.corp.adobe.com/browse/DINT-641): Adding Extensions Platform Connector Context
[DINT-678](https://jira.corp.adobe.com/browse/DINT-678): Adding Custom webSDKName
[DINT-539](https://jira.corp.adobe.com/browse/DINT-539): More unit tests

Will create another release for `@adobe/commerce-events-*` packages

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
