### PR TITLE
:bug: SEG-340 - moving segments logic into AEP collector

### DIFF
--- a/examples/old-collector-example/slim.html
+++ b/examples/old-collector-example/slim.html
@@ -7,7 +7,7 @@
         <script src="http://localhost:8080/index.js"></script>
 
         <!-- local -->
-        <script src="/index.js"></script>
+        <script src="/slim.js"></script>
 
         <!-- set up alloy externally -->
         <!-- https://experienceleague.adobe.com/docs/experience-platform/edge/fundamentals/installing-the-sdk.html?lang=en#option-2%3A-installing-the-prebuilt-standalone-version -->

--- a/examples/old-collector-example/slim.js
+++ b/examples/old-collector-example/slim.js
@@ -16,6 +16,8 @@ import {
     mockStorefront,
 } from "../../packages/commerce-events-collectors/tests/utils/mocks";
 
+console.log("load slim.js");
+
 const mse = window.magentoStorefrontEvents;
 
 mse.context.setAccount(mockAccount);
@@ -39,6 +41,7 @@ mse.context.setAEP({
     imsOrgId: "53A16ACB5CC1D3760A495C99@AdobeOrg",
     // datastreamId: "1144fb8d-b234-4c44-85ac-af91ed64c2dd:dev", // aniham
     datastreamId: "4d8ccd3b-9463-43bf-862a-c908fad3b20b", // beacon
+    webSdkName: "mycustomname",
 });
 mse.context.setEventForwarding({
     commerce: true,

--- a/packages/storefront-events-collector/src/aep/types/alloy.types.ts
+++ b/packages/storefront-events-collector/src/aep/types/alloy.types.ts
@@ -1,4 +1,4 @@
-import { BeaconSchema } from "../../types/aep";
+import { AlloySendEventResponse, BeaconSchema } from "../../types/aep";
 
 export type CommandType = "configure" | "sendEvent" | "getIdentity" | "setConsent" | "getLibraryInfo";
 
@@ -41,7 +41,7 @@ export type consentOptions = {
 export type AlloyInstance = (
     command: CommandType,
     options?: ConfigOptions | XDM<BeaconSchema> | consentOptions,
-) => Promise<void | AlloyIndentity>;
+) => Promise<void | AlloyIndentity | AlloySendEventResponse>;
 
 export type AlloyIndentity = {
     identity: {

--- a/packages/storefront-events-collector/src/alloy.ts
+++ b/packages/storefront-events-collector/src/alloy.ts
@@ -2,6 +2,7 @@
 import { AlloyIndentity, AlloyInstance, ConfigOptions } from "./aep/types/alloy.types";
 import createContext from "./contexts/aep";
 import { BeaconSchema } from "./types/aep";
+import { AlloySendEventResponse } from "./types/aep/segments";
 import { AEPContext } from "./types/contexts";
 
 let alloyInstance: AlloyInstance;
@@ -48,7 +49,7 @@ const setExistingAlloy = async (name: string) => {
 /**
  * sends event payload that matches the BeaconSchema that's been defined
  */
-const sendEvent = async (schema: BeaconSchema): Promise<void> => {
+const sendEvent = async (schema: BeaconSchema): Promise<AlloySendEventResponse | undefined> => {
     try {
         // attach identity field
         const result: AlloyIndentity = (await alloyInstance("getIdentity")) as AlloyIndentity;
@@ -57,7 +58,9 @@ const sendEvent = async (schema: BeaconSchema): Promise<void> => {
         const xdm = { xdm: { ...schema } };
 
         // send async
-        await alloyInstance("sendEvent", xdm);
+        const response = (await alloyInstance("sendEvent", xdm)) as AlloySendEventResponse;
+
+        return response;
     } catch (error) {
         // eslint-disable-next-line no-console
         console.error("sendEvent error:", error);

--- a/packages/storefront-events-collector/src/handlers/page/viewAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/page/viewAEP.ts
@@ -1,6 +1,7 @@
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
 
 import { sendEvent } from "../../alloy";
+import { getSegmentIds, setAdobeCommerceAEPSegmentCookies } from "../../segments";
 import { BeaconSchema } from "../../types/aep";
 
 const XDM_EVENT_TYPE = "web.webpagedetails.pageViews";
@@ -29,7 +30,11 @@ const aepHandler = async (event: Event): Promise<void> => {
     payload._id = debugContext?.eventId;
     payload.eventType = XDM_EVENT_TYPE;
 
-    sendEvent(payload);
+    const response = await sendEvent(payload);
+
+    // TODO: make sure context is set to use segments
+    const userSegmentIds = getSegmentIds(response?.destinations);
+    setAdobeCommerceAEPSegmentCookies(userSegmentIds);
 };
 
 export default aepHandler;

--- a/packages/storefront-events-collector/src/index.ts
+++ b/packages/storefront-events-collector/src/index.ts
@@ -3,6 +3,7 @@
 import { createInstance } from "@adobe/alloy";
 import { configure, hasConfig, setConsent, setExistingAlloy } from "./alloy";
 import { subscribeToEvents } from "./events";
+import { clearAdobeCommerceAEPSegmentCookies } from "./segments";
 import { configureSnowplow } from "./snowplow";
 
 /**
@@ -33,6 +34,9 @@ const addCustomNameToAlloyNamespace = (customName: string) =>
 /** initialize alloy if magentoStorefrontEvents exists and aep is set to true */
 const initializeAlloy = async () => {
     try {
+        // need to clear any existing cookies just to avoid any conflicts
+        clearAdobeCommerceAEPSegmentCookies();
+
         const sdk = window.magentoStorefrontEvents;
         const customName = sdk.context.getAEP().webSdkName;
 
@@ -44,7 +48,7 @@ const initializeAlloy = async () => {
             if (!hasConfig()) {
                 return;
             }
-            
+
             const name = "alloy";
             // if we don't add the name to the namespace,
             // we get a error saying window[data.instance] doesn't exist

--- a/packages/storefront-events-collector/src/segments.ts
+++ b/packages/storefront-events-collector/src/segments.ts
@@ -1,0 +1,31 @@
+/**
+ * The name of the cookie to save so that adobe commerce can read in the segment information.
+ *
+ * Should match up with Github located at:
+ * @link https://github.com/magento-commerce/segments-service/blob/main/Segment/Model/SegmentResolver.php#L13
+ */
+const ADOBE_COMMERCE_AEP_SEGMENT_MEMBERSHIP_COOKIE_NAME = "aep-segments-membership";
+
+/**
+ * Clear the browsers cookies set for Adobe Commerce AEP Segments
+ */
+export const clearAdobeCommerceAEPSegmentCookies = () => {
+    document.cookie = `${ADOBE_COMMERCE_AEP_SEGMENT_MEMBERSHIP_COOKIE_NAME}=; expires=Fri, 31 Dec 1999 23:59:59 GMT;`;
+};
+
+/**
+ * Set the browser cookies with the returned segmentMembershipIds from the proxy service
+ *
+ * @note for now we'll keep the `expires` param for cookies set to default.
+ *
+ * @param userSegmentIds comma delimited string of `segmentMembershipIds` that is returned from the proxy service
+ */
+export const setAdobeCommerceAEPSegmentCookies = (userSegmentIds = "") => {
+    //again, note that no expiration is set, so this will be a session cookie
+    document.cookie = `${ADOBE_COMMERCE_AEP_SEGMENT_MEMBERSHIP_COOKIE_NAME}=${userSegmentIds};path=/`;
+};
+
+// i'm not sure the shape of this object so i'm just typing as any to avoid errors
+export const getSegmentIds = (destinations = []) => {
+    return destinations.map(({ segments }: any) => segments.map(({ id }: any) => id)).join(",") || "";
+};

--- a/packages/storefront-events-collector/src/types/aep/index.ts
+++ b/packages/storefront-events-collector/src/types/aep/index.ts
@@ -2,3 +2,4 @@ export * from "./beaconSchema";
 export * from "./commerce";
 export * from "./pageView";
 export * from "./productListItem";
+export * from "./segments";

--- a/packages/storefront-events-collector/src/types/aep/segments.ts
+++ b/packages/storefront-events-collector/src/types/aep/segments.ts
@@ -1,0 +1,3 @@
+export type AlloySendEventResponse = {
+    destinations: [];
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Move segments logic of setting cookie into the aep collector:

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There is not much of a reason for having a separate library for segments. Initially, there was more planned, but scope was scaled back and there is not much more needed on the client side besides setting a cookie based on an event response.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
