### PR TITLE
DINT-744: better event input handling for collector

### DIFF
--- a/packages/storefront-events-collector/src/handlers/checkout/placeOrderAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/checkout/placeOrderAEP.ts
@@ -20,10 +20,10 @@ const aepHandler = async (event: Event): Promise<void> => {
         payload = {
             commerce: {
                 order: createOrder(orderContext, storefrontInstanceContext),
-                promotionID: orderContext.appliedCouponCode,
+                promotionID: orderContext?.appliedCouponCode,
                 shipping: {
-                    shippingMethod: orderContext.shipping?.shippingMethod,
-                    shippingAmount: Number(orderContext.shipping?.shippingAmount) || 0,
+                    shippingMethod: orderContext?.shipping?.shippingMethod,
+                    shippingAmount: Number(orderContext?.shipping?.shippingAmount) || 0,
                 },
             },
             productListItems: createProductListItems(shoppingCartContext, storefrontInstanceContext),

--- a/packages/storefront-events-collector/src/handlers/page/viewAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/page/viewAEP.ts
@@ -20,8 +20,8 @@ const aepHandler = async (event: Event): Promise<void> => {
                     pageViews: {
                         value: 1,
                     },
-                    siteSection: pageContext.pageType,
-                    name: pageContext.pageName,
+                    siteSection: pageContext?.pageType,
+                    name: pageContext?.pageName,
                 },
             },
         };

--- a/packages/storefront-events-collector/src/handlers/product/addToCart.ts
+++ b/packages/storefront-events-collector/src/handlers/product/addToCart.ts
@@ -5,7 +5,9 @@ import { createProductCtx, createShoppingCartCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
     const { changedProductsContext, pageContext, productContext, shoppingCartContext } = event.eventInfo;
-    changedProductsContext.items?.forEach((item) => {
+
+    const cartItems = changedProductsContext?.items || shoppingCartContext?.items || [];
+    cartItems?.forEach((item) => {
         let productCtx;
         if(item.product.sku === productContext.sku){
             productCtx = createProductCtx(productContext);

--- a/packages/storefront-events-collector/src/handlers/product/addToCartAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/product/addToCartAEP.ts
@@ -18,7 +18,7 @@ const aepHandler = async (event: Event): Promise<void> => {
         payload = {
             commerce: {
                 cart: {
-                    cartID: shoppingCartContext.id,
+                    cartID: shoppingCartContext?.id,
                 },
             },
             productListItems: createProductListItems(changedProductsContext, storefrontInstanceContext)

--- a/packages/storefront-events-collector/src/handlers/product/removeFromCartAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/product/removeFromCartAEP.ts
@@ -18,7 +18,7 @@ const aepHandler = async (event: Event): Promise<void> => {
         payload = {
             commerce: {
                 cart: {
-                    cartID: shoppingCartContext.id,
+                    cartID: shoppingCartContext?.id,
                 },
             },
             productListItems: createProductListItems(changedProductsContext, storefrontInstanceContext),

--- a/packages/storefront-events-collector/src/handlers/product/viewAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/product/viewAEP.ts
@@ -15,12 +15,12 @@ const aepHandler = async (event: Event): Promise<void> => {
         payload = customContext as BeaconSchema;
     } else {
         const productListItem: ProductListItem = {
-            SKU: productContext.sku,
-            name: productContext.name,
-            productImageUrl: productContext.mainImageUrl,
-            priceTotal: productContext.pricing?.specialPrice ?? productContext.pricing?.regularPrice,
+            SKU: productContext?.sku,
+            name: productContext?.name,
+            productImageUrl: productContext?.mainImageUrl,
+            priceTotal: productContext?.pricing?.specialPrice ?? productContext?.pricing?.regularPrice,
             currencyCode:
-                productContext.pricing?.currencyCode ?? storefrontInstanceContext.storeViewCurrencyCode ?? undefined,
+                productContext?.pricing?.currencyCode ?? storefrontInstanceContext?.storeViewCurrencyCode ?? undefined,
             discountAmount: getDiscountAmount(productContext),
         };
 

--- a/packages/storefront-events-collector/src/handlers/search/searchRequestSentAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/search/searchRequestSentAEP.ts
@@ -50,7 +50,7 @@ const handler = async (event: Event): Promise<void> => {
 
         payload = {
             siteSearch: {
-                query: searchInputContext.units[0].phrase,
+                query: searchInputContext?.units[0].phrase,
                 sort,
                 refinements: filters,
             },

--- a/packages/storefront-events-collector/src/handlers/shoppingCart/initiateCheckoutAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/shoppingCart/initiateCheckoutAEP.ts
@@ -17,7 +17,7 @@ const handler = async (event: Event): Promise<void> => {
         payload = {
             commerce: {
                 cart: {
-                    cartID: shoppingCartContext.id,
+                    cartID: shoppingCartContext?.id,
                 },
             },
             productListItems: createProductListItems(shoppingCartContext, storefrontInstanceContext),

--- a/packages/storefront-events-collector/src/handlers/shoppingCart/openCartAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/shoppingCart/openCartAEP.ts
@@ -16,7 +16,7 @@ const handler = async (event: Event): Promise<void> => {
         payload = {
             commerce: {
                 cart: {
-                    cartID: shoppingCartContext.id,
+                    cartID: shoppingCartContext?.id,
                 },
             },
             productListItems: createProductListItems(changedProductsContext, storefrontInstanceContext),

--- a/packages/storefront-events-collector/src/handlers/shoppingCart/viewAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/shoppingCart/viewAEP.ts
@@ -18,7 +18,7 @@ const aepHandler = async (event: Event): Promise<void> => {
         payload = {
             commerce: {
                 cart: {
-                    cartID: shoppingCartContext.id,
+                    cartID: shoppingCartContext?.id,
                 },
                 productListViews: {
                     value: 1,

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -3,7 +3,6 @@ import * as sdkSchemas from "@adobe/magento-storefront-events-sdk/dist/types/typ
 import { Order, Payment } from "../../types/aep";
 
 const getAepPaymentCode = (paymentMethodCode: string) => {
-    //Code support reasoning documented here: https://jira.corp.adobe.com/browse/DINT-324
     switch (paymentMethodCode) {
         case "checkmo":
             return "check";
@@ -25,34 +24,34 @@ const createOrder = (
 ): Order => {
     let payments: Payment[] = [];
 
-    if (orderContext.payments && orderContext.payments.length) {
+    if (orderContext?.payments?.length) {
         // try payments array first
         payments = orderContext.payments.map((payment) => {
             return {
                 paymentAmount: payment.total,
                 paymentType: getAepPaymentCode(payment.paymentMethodCode),
-                transactionID: orderContext.orderId.toString(),
-                currencyCode: storefrontInstanceContext.storeViewCurrencyCode,
+                transactionID: orderContext?.orderId.toString(),
+                currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
             };
         });
     } else {
         // no payments array, try deprecated top level payment fields
         payments = [
             {
-                paymentAmount: orderContext.grandTotal,
-                paymentType: getAepPaymentCode(orderContext.paymentMethodCode),
-                transactionID: orderContext.orderId.toString(),
-                currencyCode: storefrontInstanceContext.storeViewCurrencyCode,
+                paymentAmount: orderContext?.grandTotal,
+                paymentType: getAepPaymentCode(orderContext?.paymentMethodCode),
+                transactionID: orderContext?.orderId?.toString(),
+                currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
             },
         ];
     }
 
     // default orderType to 'checkout'
-    const orderType = orderContext.orderType === "instant_purchase" ? "instant_purchase" : "checkout";
+    const orderType = orderContext?.orderType === "instant_purchase" ? "instant_purchase" : "checkout";
 
     return {
-        purchaseID: orderContext.orderId.toString(),
-        currencyCode: storefrontInstanceContext.storeViewCurrencyCode,
+        purchaseID: orderContext?.orderId.toString(),
+        currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
         payments,
         orderType,
     };

--- a/packages/storefront-events-collector/src/utils/aep/productListItems.ts
+++ b/packages/storefront-events-collector/src/utils/aep/productListItems.ts
@@ -13,21 +13,21 @@ const createProductListItems = (
     storefrontContext: StorefrontInstance,
 ): ProductListItem[] => {
     const returnList: ProductListItem[] = [];
-    if (cartContext.items?.length) {
+    if (cartContext?.items?.length) {
         cartContext.items.forEach((item) => {
             const selectedOptions: SelectedOption[] = [];
             item.configurableOptions?.forEach((option) => {
                 selectedOptions.push({
-                    attribute: option.optionLabel,
-                    value: option.valueLabel,
+                    attribute: String(option.optionLabel),
+                    value: String(option.valueLabel),
                 });
             });
 
             const productListItem: ProductListItem = {
-                SKU: item.product.sku,
-                name: item.product.name,
+                SKU: item.product?.sku,
+                name: item.product?.name,
                 quantity: item.quantity,
-                priceTotal: item.prices.price.value * item.quantity,
+                priceTotal: (item.prices?.price?.value * item.quantity) || 0,
                 productImageUrl: item.product.mainImageUrl,
                 currencyCode: item.prices.price.currency ?? storefrontContext.storeViewCurrencyCode,
                 discountAmount: getDiscountAmount(item.product),

--- a/packages/storefront-events-collector/src/utils/discount.ts
+++ b/packages/storefront-events-collector/src/utils/discount.ts
@@ -1,13 +1,13 @@
 import { Product } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 
 /** calculates the discountAmount from a Product object */
-export const getDiscountAmount = ({ pricing }: Product): number | undefined => {
+export const getDiscountAmount = ({ pricing }: Product): number  => {
     if (!pricing) {
-        return undefined;
+        return 0;
     }
 
     const { regularPrice, specialPrice } = pricing;
     const discount = regularPrice - (specialPrice ?? regularPrice);
 
-    return discount;
+    return discount || 0;
 };


### PR DESCRIPTION
call createChangeProductsContext rather than getting it [straight from eventInfo](https://github.com/adobe/commerce-events/blob/main/packages/storefront-events-collector/src/handlers/product/addToCart.ts#L7)

do a broader sweep to see where else we break in the same way for unset contexts

cast as number values that the AEP schema accepts (discountAmount, totalPrice - when these are buggy in the instrumentation, they show up as `NaN`/`undefined` in AEP and break dataset ingestion)

must also cast `selectedOptions` (client reported error: - Details: "The message can't be validated due to the data type error: `#/productListItems/0/selectedOptions/0/value`: expected type: `String`, found: `JSONArray`.")
