### PR TITLE
enforce paymentAmount to Number

### DIFF
--- a/packages/commerce-events-collectors/src/utils/aep/order.ts
+++ b/packages/commerce-events-collectors/src/utils/aep/order.ts
@@ -29,7 +29,7 @@ const createOrder = (
         // try payments array first
         payments = orderContext.payments.map((payment) => {
             return {
-                paymentAmount: payment.total,
+                paymentAmount: Number(payment.total),
                 paymentType: getAepPaymentCode(payment.paymentMethodCode),
                 transactionID: orderContext.orderId.toString(),
                 currencyCode: storefrontInstanceContext.storeViewCurrencyCode,
@@ -39,7 +39,7 @@ const createOrder = (
         // no payments array, try deprecated top level payment fields
         payments = [
             {
-                paymentAmount: orderContext.grandTotal,
+                paymentAmount: Number(orderContext.grandTotal),
                 paymentType: getAepPaymentCode(orderContext.paymentMethodCode),
                 transactionID: orderContext.orderId.toString(),
                 currencyCode: storefrontInstanceContext.storeViewCurrencyCode,

--- a/packages/commerce-events-collectors/src/utils/aep/order.ts
+++ b/packages/commerce-events-collectors/src/utils/aep/order.ts
@@ -29,7 +29,7 @@ const createOrder = (
         // try payments array first
         payments = orderContext.payments.map((payment) => {
             return {
-                paymentAmount: Number(payment.total),
+                paymentAmount: Number(payment.total || 0),
                 paymentType: getAepPaymentCode(payment.paymentMethodCode),
                 transactionID: orderContext.orderId.toString(),
                 currencyCode: storefrontInstanceContext.storeViewCurrencyCode,
@@ -39,7 +39,7 @@ const createOrder = (
         // no payments array, try deprecated top level payment fields
         payments = [
             {
-                paymentAmount: Number(orderContext.grandTotal),
+                paymentAmount: Number(orderContext.grandTotal || 0),
                 paymentType: getAepPaymentCode(orderContext.paymentMethodCode),
                 transactionID: orderContext.orderId.toString(),
                 currencyCode: storefrontInstanceContext.storeViewCurrencyCode,

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -28,7 +28,7 @@ const createOrder = (
         // try payments array first
         payments = orderContext.payments.map((payment) => {
             return {
-                paymentAmount: Number(payment.total),
+                paymentAmount: Number(payment.total || 0),
                 paymentType: getAepPaymentCode(payment.paymentMethodCode),
                 transactionID: orderContext?.orderId.toString(),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
@@ -38,7 +38,7 @@ const createOrder = (
         // no payments array, try deprecated top level payment fields
         payments = [
             {
-                paymentAmount: Number(orderContext?.grandTotal),
+                paymentAmount: Number(orderContext?.grandTotal || 0),
                 paymentType: getAepPaymentCode(orderContext?.paymentMethodCode),
                 transactionID: orderContext?.orderId?.toString(),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -28,7 +28,7 @@ const createOrder = (
         // try payments array first
         payments = orderContext.payments.map((payment) => {
             return {
-                paymentAmount: payment.total,
+                paymentAmount: Number(payment.total),
                 paymentType: getAepPaymentCode(payment.paymentMethodCode),
                 transactionID: orderContext?.orderId.toString(),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
@@ -38,7 +38,7 @@ const createOrder = (
         // no payments array, try deprecated top level payment fields
         payments = [
             {
-                paymentAmount: orderContext?.grandTotal,
+                paymentAmount: Number(orderContext?.grandTotal),
                 paymentType: getAepPaymentCode(orderContext?.paymentMethodCode),
                 transactionID: orderContext?.orderId?.toString(),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

paymentAmount is being sent as string to AEP which is causing event ingestion error for commerce.purchases event.  Here we are enforcing Numeric coercion.

## Related Issue

[<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->](https://jira.corp.adobe.com/browse/DINT-767)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Local testing, will continue some cloud and end to end AEP testing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
