### PR TITLE
Fix alloy initialization logic to accurately reflect EPC admin config.

### DIFF
--- a/packages/storefront-events-collector/src/index.ts
+++ b/packages/storefront-events-collector/src/index.ts
@@ -75,7 +75,7 @@ const initialize = async () => {
     const eventForwarding = context.getEventForwarding();
 
     const sendToSnowplow = eventForwarding?.commerce === false ? false : true;
-    const sendToAEP = eventForwarding?.aep === hasConfig() ? true : false;
+    const sendToAEP = eventForwarding?.aep && hasConfig() ? true : false;
 
     if (sendToSnowplow) {
         configureSnowplow({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed conditional logic to properly handle AEP event forwarding when set to false.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/DINT-1167

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
https://jira.corp.adobe.com/browse/DINT-1167

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually following reproduction steps in ticket and using [this documentation](https://wiki.corp.adobe.com/display/ACDS/How+to+Test+external+Web+SDK+in+EPC) to configure alloy library "externally"
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
