### PR TITLE
DINT-1203 Fix incorrect topLevelSku

### DIFF
--- a/packages/storefront-events-collector/src/handlers/product/addToCart.ts
+++ b/packages/storefront-events-collector/src/handlers/product/addToCart.ts
@@ -9,7 +9,7 @@ const handler = (event: Event): void => {
     const cartItems = changedProductsContext?.items || shoppingCartContext?.items || [];
     cartItems?.forEach((item) => {
         let productCtx;
-        if (item.product.sku === productContext.sku) {
+        if (item.product.sku === productContext?.sku) {
             productCtx = createProductCtx(productContext);
         } else {
             productCtx = createProductFromCartItem(item);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

[<!--- Describe your changes in detail -->](https://jira.corp.adobe.com/browse/DINT-1203)
Fix an issue with lingering product context in PR in magento2-snowplow-js.  Now the snowplow handler may not have product context, so we have to add appropriate check to ensure no error occurs.
https://git.corp.adobe.com/magento-datalake/magento2-snowplow-js/pull/242

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/DINT-1203
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ x My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
