### PR TITLE
DINT-1175: Fix multi-shipping payment handling

### DIFF
--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -35,7 +35,7 @@ const createOrder = (
             return {
                 paymentAmount: Number(payment.total || 0),
                 paymentType: getAepPaymentCode(payment.paymentMethodCode),
-                transactionID: payment.orderId ? String(payment.orderId) : String(orderContext?.orderId),
+                transactionID: payment?.orderId ? String(payment.orderId) : String(orderContext?.orderId),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
             };
         });

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -35,7 +35,7 @@ const createOrder = (
             return {
                 paymentAmount: Number(payment.total || 0),
                 paymentType: getAepPaymentCode(payment.paymentMethodCode),
-                transactionID: String(orderContext?.orderId),
+                transactionID: payment.orderId ? String(payment.orderId) : String(orderContext?.orderId),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
             };
         });

--- a/packages/storefront-events-sdk/src/types/schemas/order.ts
+++ b/packages/storefront-events-sdk/src/types/schemas/order.ts
@@ -20,6 +20,7 @@ export type Payment = {
     paymentMethodCode: string;
     paymentMethodName: string;
     total: number;
+    orderId?: string;
 };
 
 export type Shipping = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Payment arrays were not being correctly created in DataServices, but have fixed that in PR https://github.com/magento-commerce/data-services/pull/198
In combination with that PR we are now adding orderID to the transactionID field correctly when multiple orders are placed due to multishipping.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DINT-1175
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
