### PR TITLE
DSCS-863: add minLength to all required schema fields, where applicable

### DIFF
--- a/examples/events/snowplow-debugger/product.json
+++ b/examples/events/snowplow-debugger/product.json
@@ -9,7 +9,8 @@
       },
       "sku": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "topLevelSku": {
         "type": [

--- a/examples/events/snowplow-debugger/product.json
+++ b/examples/events/snowplow-debugger/product.json
@@ -172,7 +172,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "product",
       "format": "jsonschema",
-      "version": "2-1-0"
+      "version": "2-0-6"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/product.json
+++ b/examples/events/snowplow-debugger/product.json
@@ -172,7 +172,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "product",
       "format": "jsonschema",
-      "version": "2-0-6"
+      "version": "3-0-0"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/product.json
+++ b/examples/events/snowplow-debugger/product.json
@@ -5,7 +5,9 @@
         "type": "integer"
       },
       "name": {
-        "maxLength": 256
+        "type": "string",
+        "maxLength": 256,
+        "minLength": 1
       },
       "sku": {
         "type": "string",
@@ -172,7 +174,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "product",
       "format": "jsonschema",
-      "version": "3-0-0"
+      "version": "2-0-7"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/product.json
+++ b/examples/events/snowplow-debugger/product.json
@@ -172,7 +172,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "product",
       "format": "jsonschema",
-      "version": "2-0-5"
+      "version": "2-1-0"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/recommendation-unit.json
+++ b/examples/events/snowplow-debugger/recommendation-unit.json
@@ -3,11 +3,13 @@
     "properties": {
       "name": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "unitId": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "itemsCount": {
         "type": "integer"
@@ -17,15 +19,18 @@
       },
       "configType": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "source": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "recType": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "placement": {
         "type": [
@@ -63,8 +68,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "recommendation-unit",
       "format": "jsonschema",
-      "version": "1-0-4"
+      "version": "1-0-5"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }
-  

--- a/examples/events/snowplow-debugger/recommended-item.json
+++ b/examples/events/snowplow-debugger/recommended-item.json
@@ -3,7 +3,8 @@
     "properties": {
       "unitId": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "serviceRank": {
         "type": "integer"
@@ -13,15 +14,18 @@
       },
       "name": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "sku": {
         "type": "string",
-        "maxLength": 64
+        "maxLength": 64,
+        "minLength": 1
       },
       "url": {
         "type": "string",
-        "maxLength": 2083
+        "maxLength": 2083,
+        "minLength": 1
       },
       "imageUrl": {
         "type": [
@@ -54,7 +58,8 @@
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "amount": {
                       "type": "number"
@@ -73,7 +78,8 @@
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "amount": {
                       "type": "number"
@@ -114,7 +120,8 @@
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "amount": {
                       "type": "number"
@@ -133,7 +140,8 @@
                   "type": "object",
                   "properties": {
                     "code": {
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "amount": {
                       "type": "number"
@@ -183,8 +191,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "recommended-item",
       "format": "jsonschema",
-      "version": "1-0-4"
+      "version": "1-0-5"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }
-  

--- a/examples/events/snowplow-debugger/recs-api-request.json
+++ b/examples/events/snowplow-debugger/recs-api-request.json
@@ -22,21 +22,24 @@
         ]
       },
       "websiteCode": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "storeId": {
         "type": "integer"
       },
       "storeCode": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "storeViewId": {
         "type": "integer"
       },
       "storeViewCode": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "defaultStoreViewCode": {
         "type": [
@@ -168,8 +171,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "recs-api-request",
       "format": "jsonschema",
-      "version": "2-0-13"
+      "version": "2-0-14"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }
-  

--- a/examples/events/snowplow-debugger/recs-api-response.json
+++ b/examples/events/snowplow-debugger/recs-api-response.json
@@ -41,4 +41,3 @@
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }
-  

--- a/examples/events/snowplow-debugger/search-input.json
+++ b/examples/events/snowplow-debugger/search-input.json
@@ -86,7 +86,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "search-input",
       "format": "jsonschema",
-      "version": "1-0-12"
+      "version": "2-0-1"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/search-input.json
+++ b/examples/events/snowplow-debugger/search-input.json
@@ -2,7 +2,8 @@
     "description": "Schema for Search Input Entity",
     "properties": {
       "searchUnitId": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "source": {
         "type": [
@@ -11,7 +12,8 @@
         ]
       },
       "queryTypes": {
-        "type": "array"
+        "type": "array",
+        "minLength": 1
       },
       "searchRequestId": {
         "type": "string",
@@ -19,7 +21,8 @@
         "minLength": 1
       },
       "query": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "page": {
         "type": "number"
@@ -83,7 +86,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "search-input",
       "format": "jsonschema",
-      "version": "1-0-11"
+      "version": "1-0-12"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/search-result-product.json
+++ b/examples/events/snowplow-debugger/search-result-product.json
@@ -2,19 +2,23 @@
     "description": "Schema for Product Search Result Entity",
     "properties": {
       "name": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "url": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "rank": {
         "type": "number"
       },
       "sku": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "imageUrl": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "price": {
         "type": "number"
@@ -33,8 +37,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "search-result-product",
       "format": "jsonschema",
-      "version": "1-0-2"
+      "version": "1-0-3"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }
-  

--- a/examples/events/snowplow-debugger/search-results.json
+++ b/examples/events/snowplow-debugger/search-results.json
@@ -217,7 +217,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "search-results",
       "format": "jsonschema",
-      "version": "1-0-12"
+      "version": "2-0-1"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/search-results.json
+++ b/examples/events/snowplow-debugger/search-results.json
@@ -2,7 +2,8 @@
     "description": "Schema for Search Results Entity",
     "properties": {
       "searchUnitId": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       },
       "searchRequestId": {
         "type": "string",
@@ -27,19 +28,23 @@
           "description": "Schema for Product Search Result Entity",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "rank": {
               "type": "number"
             },
             "sku": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "imageUrl": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "price": {
               "type": "number"
@@ -72,7 +77,8 @@
           "description": "Schema for Suggestion Search Results ",
           "properties": {
             "suggestion": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "rank": {
               "type": "number"
@@ -102,10 +108,12 @@
           "description": "Schema for Category Search Results",
           "properties": {
             "name": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "url": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "rank": {
               "type": "number"
@@ -150,20 +158,25 @@
         "items": {
           "properties": {
             "attribute": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "title": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "type": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "buckets": {
               "type": "array",
+              "minLength": 1,
               "items": {
                 "properties": {
                   "title": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                   }
                 },
                 "type": "object",
@@ -204,7 +217,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "search-results",
       "format": "jsonschema",
-      "version": "1-0-11"
+      "version": "1-0-12"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }

--- a/examples/events/snowplow-debugger/shopping-cart.json
+++ b/examples/events/snowplow-debugger/shopping-cart.json
@@ -29,14 +29,17 @@
             },
             "productName": {
               "type": "string",
-              "maxLength": 256
+              "maxLength": 256,
+              "minLength": 1
             },
             "cartItemId": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "productSku": {
               "type": "string",
-              "maxLength": 256
+              "maxLength": 256,
+              "minLength": 1
             },
             "mainImageUrl": {
               "type": "string",
@@ -79,8 +82,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "shopping-cart",
       "format": "jsonschema",
-      "version": "2-0-0"
+      "version": "2-0-1"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }
-  

--- a/examples/events/snowplow-debugger/storefront-instance.json
+++ b/examples/events/snowplow-debugger/storefront-instance.json
@@ -3,7 +3,8 @@
     "properties": {
       "environmentId": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "instanceId": {
         "type": "string",
@@ -11,11 +12,13 @@
       },
       "environment": {
         "type": "string",
-        "maxLength": 16
+        "maxLength": 16,
+        "minLength": 1
       },
       "storeUrl": {
         "type": "string",
-        "maxLength": 2083
+        "maxLength": 2083,
+        "minLength": 1
       },
       "websiteId": {
         "type": "integer"
@@ -40,23 +43,28 @@
       },
       "websiteName": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "storeName": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "storeViewName": {
         "type": "string",
-        "maxLength": 256
+        "maxLength": 256,
+        "minLength": 1
       },
       "baseCurrencyCode": {
         "type": "string",
-        "maxLength": 3
+        "maxLength": 3,
+        "minLength": 1
       },
       "storeViewCurrencyCode": {
         "type": "string",
-        "maxLength": 3
+        "maxLength": 3,
+        "minLength": 1
       },
       "catalogExtensionVersion": {
         "type": [
@@ -89,8 +97,7 @@
       "vendor": "com.adobe.magento.entity",
       "name": "storefront-instance",
       "format": "jsonschema",
-      "version": "3-0-1"
+      "version": "3-0-2"
     },
     "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#"
   }
-  

--- a/packages/storefront-events-collector/src/schemas.ts
+++ b/packages/storefront-events-collector/src/schemas.ts
@@ -6,7 +6,7 @@ const schemas = {
     EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/experience-platform-connector-extension/jsonschema/1-0-1",
     MAGENTO_JS_TRACKER_SCHEMA_URL: "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/2-0-0",
-    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-0-5",
+    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-1-0",
     RECOMMENDATION_UNIT_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",
     RECOMMENDED_ITEM_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-4",
     SEARCH_INPUT_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-input/jsonschema/2-0-0",

--- a/packages/storefront-events-collector/src/schemas.ts
+++ b/packages/storefront-events-collector/src/schemas.ts
@@ -6,7 +6,7 @@ const schemas = {
     EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/experience-platform-connector-extension/jsonschema/1-0-1",
     MAGENTO_JS_TRACKER_SCHEMA_URL: "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/2-0-0",
-    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-0-6",
+    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/3-0-0",
     RECOMMENDATION_UNIT_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",
     RECOMMENDED_ITEM_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-4",
     SEARCH_INPUT_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-input/jsonschema/2-0-0",

--- a/packages/storefront-events-collector/src/schemas.ts
+++ b/packages/storefront-events-collector/src/schemas.ts
@@ -6,17 +6,17 @@ const schemas = {
     EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/experience-platform-connector-extension/jsonschema/1-0-1",
     MAGENTO_JS_TRACKER_SCHEMA_URL: "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/2-0-0",
-    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/3-0-0",
-    RECOMMENDATION_UNIT_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",
-    RECOMMENDED_ITEM_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-4",
-    SEARCH_INPUT_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-input/jsonschema/2-0-0",
+    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-0-7",
+    RECOMMENDATION_UNIT_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-5",
+    RECOMMENDED_ITEM_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-5",
+    SEARCH_INPUT_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-input/jsonschema/2-0-1",
     SEARCH_RESULT_CATEGORY_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-result-category/jsonschema/1-0-1",
-    SEARCH_RESULT_PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-2",
-    SEARCH_RESULTS_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-results/jsonschema/2-0-0",
+    SEARCH_RESULT_PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-result-product/jsonschema/1-0-3",
+    SEARCH_RESULTS_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-results/jsonschema/2-0-1",
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
-    SHOPPING_CART_SCHEMA_URL: "iglu:com.adobe.magento.entity/shopping-cart/jsonschema/2-0-0",
+    SHOPPING_CART_SCHEMA_URL: "iglu:com.adobe.magento.entity/shopping-cart/jsonschema/2-0-1",
     SHOPPER_SCHEMA_URL: "iglu:com.adobe.magento.entity/shopper/jsonschema/1-0-0",
-    STOREFRONT_INSTANCE_SCHEMA_URL: "iglu:com.adobe.magento.entity/storefront-instance/jsonschema/3-0-1",
+    STOREFRONT_INSTANCE_SCHEMA_URL: "iglu:com.adobe.magento.entity/storefront-instance/jsonschema/3-0-2",
 };
 
 export default schemas;

--- a/packages/storefront-events-collector/src/schemas.ts
+++ b/packages/storefront-events-collector/src/schemas.ts
@@ -6,7 +6,7 @@ const schemas = {
     EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_SCHEMA_URL:
         "iglu:com.adobe.magento.entity/experience-platform-connector-extension/jsonschema/1-0-1",
     MAGENTO_JS_TRACKER_SCHEMA_URL: "iglu:com.adobe.magento.entity/magento-js-tracker/jsonschema/2-0-0",
-    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-1-0",
+    PRODUCT_SCHEMA_URL: "iglu:com.adobe.magento.entity/product/jsonschema/2-0-6",
     RECOMMENDATION_UNIT_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommendation-unit/jsonschema/1-0-4",
     RECOMMENDED_ITEM_SCHEMA_URL: "iglu:com.adobe.magento.entity/recommended-item/jsonschema/1-0-4",
     SEARCH_INPUT_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-input/jsonschema/2-0-0",


### PR DESCRIPTION
## Description

While we assert in the product schema that the `sku` field is not null, it should also not be an empty string. Recently ran into some customer issues where an empty sku field left events unprocessed. This schema needs to be updated in the snowplow console, but I will wait for feedback here before making any schema changes. Also interested in the process for updating this schema within snowplow.

## Related Issue

Please see internal adobe jira issue DSCS-863.

## Motivation and Context

`sku` is a required field, which means it should also not be empty.

## How Has This Been Tested?

Downstream processing pipelines for recommendations were breaking because the sku field was empty for some events for some customers. In those pipelines queries that assumed the sku would not be empty on product events have been updated to explicitly remove empty strings as well as the null values so that the pipelines do not error with missing sku information. Twofold, schema validation should also handle empty product event sku information so that events that do not meet our expectations fail fast and return accurate assumptions to our customers about which product information may be missing required sku data.

## Screenshots (if appropriate):

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly. - _I believe the schema is self documenting, but happy to update other docs if necessary_
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
