### PR TITLE
DINT-1336 Enforce numeric discount amount

### DIFF
--- a/packages/storefront-events-collector/src/handlers/checkout/placeOrderAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/checkout/placeOrderAEP.ts
@@ -10,53 +10,57 @@ const XDM_EVENT_TYPE = "commerce.purchases";
 
 /** Sends an event to aep with a checkout complete payload */
 const aepHandler = async (event: Event): Promise<void> => {
-    const {
-        accountContext,
-        storefrontInstanceContext,
-        orderContext,
-        shoppingCartContext,
-        debugContext,
-        customContext,
-    } = event.eventInfo;
+    try{
+        const {
+            accountContext,
+            storefrontInstanceContext,
+            orderContext,
+            shoppingCartContext,
+            debugContext,
+            customContext,
+        } = event.eventInfo;
 
-    let payload: BeaconSchema = {};
-    if (customContext && Object.keys(customContext as BeaconSchema).length !== 0) {
-        // override payload on custom context
-        payload = customContext as BeaconSchema;
+        let payload: BeaconSchema = {};
+        if (customContext && Object.keys(customContext as BeaconSchema).length !== 0) {
+            // override payload on custom context
+            payload = customContext as BeaconSchema;
+        }
+
+        payload.commerce = payload.commerce || {};
+
+        payload.commerce.order = createOrder(payload.commerce.order, orderContext, storefrontInstanceContext);
+        payload.commerce.order.discountAmount =
+            Number(payload.commerce.order.discountAmount || shoppingCartContext?.discountAmount || 0);
+        payload.commerce.promotionID = payload.commerce.promotionID || orderContext?.appliedCouponCode;
+        payload.commerce.shipping = payload.commerce.shipping || {};
+        payload.commerce.shipping.shippingMethod =
+            payload.commerce.shipping.shippingMethod || orderContext?.shipping?.shippingMethod;
+        payload.commerce.shipping.shippingAmount =
+            payload.commerce.shipping.shippingAmount || Number(orderContext?.shipping?.shippingAmount) || 0;
+
+        payload.personalEmail = payload.personalEmail || {};
+        payload.personalEmail.address = payload.personalEmail.address || accountContext?.emailAddress;
+
+        payload.productListItems = createProductListItems(
+            payload.productListItems,
+            shoppingCartContext,
+            undefined,
+            storefrontInstanceContext,
+        );
+
+        payload.commerce.purchases = {
+            value: 1,
+        };
+
+        payload.commerce.commerceScope = createCommerceScope(storefrontInstanceContext);
+
+        payload._id = debugContext?.eventId;
+        payload.eventType = XDM_EVENT_TYPE;
+
+        sendEvent(payload, event);
+    } catch (e) {
+        console.warn("Error in placeOrderAEP handler");
     }
-
-    payload.commerce = payload.commerce || {};
-
-    payload.commerce.order = createOrder(payload.commerce.order, orderContext, storefrontInstanceContext);
-    payload.commerce.order.discountAmount =
-        payload.commerce.order.discountAmount || shoppingCartContext?.discountAmount || 0;
-    payload.commerce.promotionID = payload.commerce.promotionID || orderContext?.appliedCouponCode;
-    payload.commerce.shipping = payload.commerce.shipping || {};
-    payload.commerce.shipping.shippingMethod =
-        payload.commerce.shipping.shippingMethod || orderContext?.shipping?.shippingMethod;
-    payload.commerce.shipping.shippingAmount =
-        payload.commerce.shipping.shippingAmount || Number(orderContext?.shipping?.shippingAmount) || 0;
-
-    payload.personalEmail = payload.personalEmail || {};
-    payload.personalEmail.address = payload.personalEmail.address || accountContext?.emailAddress;
-
-    payload.productListItems = createProductListItems(
-        payload.productListItems,
-        shoppingCartContext,
-        undefined,
-        storefrontInstanceContext,
-    );
-
-    payload.commerce.purchases = {
-        value: 1,
-    };
-
-    payload.commerce.commerceScope = createCommerceScope(storefrontInstanceContext);
-
-    payload._id = debugContext?.eventId;
-    payload.eventType = XDM_EVENT_TYPE;
-
-    sendEvent(payload, event);
 };
 
 export default aepHandler;

--- a/packages/storefront-events-collector/src/handlers/checkout/placeOrderAEP.ts
+++ b/packages/storefront-events-collector/src/handlers/checkout/placeOrderAEP.ts
@@ -10,7 +10,7 @@ const XDM_EVENT_TYPE = "commerce.purchases";
 
 /** Sends an event to aep with a checkout complete payload */
 const aepHandler = async (event: Event): Promise<void> => {
-    try{
+    try {
         const {
             accountContext,
             storefrontInstanceContext,
@@ -29,8 +29,9 @@ const aepHandler = async (event: Event): Promise<void> => {
         payload.commerce = payload.commerce || {};
 
         payload.commerce.order = createOrder(payload.commerce.order, orderContext, storefrontInstanceContext);
-        payload.commerce.order.discountAmount =
-            Number(payload.commerce.order.discountAmount || shoppingCartContext?.discountAmount || 0);
+        payload.commerce.order.discountAmount = Number(
+            payload.commerce.order.discountAmount || shoppingCartContext?.discountAmount || 0,
+        );
         payload.commerce.promotionID = payload.commerce.promotionID || orderContext?.appliedCouponCode;
         payload.commerce.shipping = payload.commerce.shipping || {};
         payload.commerce.shipping.shippingMethod =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
0 discount amounts are coming through as strings causing AEP batch processing errors.
Going to enforce in handler to correct any upstream variance.
Also, adding try catch as Number coercion can throw errors.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/DINT-1336
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
