### PR TITLE
Revert "DINT-1312 Support payment codes for credit, debit, and gift card."

### DIFF
--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -10,12 +10,6 @@ const getAepPaymentCode = (paymentMethodCode: string) => {
             return "wire_transfer";
         case "cashondelivery":
             return "cash";
-        case "credit_card":
-            return "credit_card";
-        case "debit_card":
-            return "debit_card";
-        case "gift_card":
-            return "gift_card";
         case "purchaseorder":
         case "free":
         case "companycredit":


### PR DESCRIPTION
Reverts adobe/commerce-events#148
Seems like these requested payment codes aren't what client is requesting.  Going to back out changes, so that other commerce events commits can be released.