### PR TITLE
Dint 1312 - Removing Payment code mappings to support all payment codes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true 
+        "source.fixAll.eslint": "explicit"
     }
 }

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -2,28 +2,6 @@ import * as sdkSchemas from "@adobe/magento-storefront-events-sdk/src/types/sche
 
 import { Order, Payment } from "../../types/aep";
 
-const getAepPaymentCode = (paymentMethodCode: string) => {
-    switch (paymentMethodCode) {
-        case "checkmo":
-            return "check";
-        case "banktransfer":
-            return "wire_transfer";
-        case "cashondelivery":
-            return "cash";
-        case "credit_card":
-            return "credit_card";
-        case "debit_card":
-            return "debit_card";
-        case "gift_card":
-            return "gift_card";
-        case "purchaseorder":
-        case "free":
-        case "companycredit":
-        default:
-            return "other";
-    }
-};
-
 const createOrder = (
     orderFromCustomContext: Order | undefined,
     orderContext: sdkSchemas.Order,
@@ -40,7 +18,7 @@ const createOrder = (
         payments = orderContext.payments.map((payment) => {
             return {
                 paymentAmount: Number(payment.total || 0),
-                paymentType: getAepPaymentCode(payment.paymentMethodCode),
+                paymentType: payment.paymentMethodCode,
                 transactionID: payment?.orderId ? String(payment.orderId) : String(orderContext?.orderId),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
             };
@@ -50,7 +28,7 @@ const createOrder = (
         payments = [
             {
                 paymentAmount: Number(orderContext?.grandTotal || 0),
-                paymentType: getAepPaymentCode(orderContext?.paymentMethodCode),
+                paymentType: orderContext?.paymentMethodCode,
                 transactionID: String(orderContext?.orderId),
                 currencyCode: storefrontInstanceContext?.storeViewCurrencyCode,
             },

--- a/packages/storefront-events-collector/src/utils/aep/order.ts
+++ b/packages/storefront-events-collector/src/utils/aep/order.ts
@@ -10,6 +10,12 @@ const getAepPaymentCode = (paymentMethodCode: string) => {
             return "wire_transfer";
         case "cashondelivery":
             return "cash";
+        case "credit_card":
+            return "credit_card";
+        case "debit_card":
+            return "debit_card";
+        case "gift_card":
+            return "gift_card";
         case "purchaseorder":
         case "free":
         case "companycredit":

--- a/packages/storefront-events-collector/tests/handlers/checkout/placeOrderAEP.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/checkout/placeOrderAEP.test.ts
@@ -27,13 +27,13 @@ test("correctly structures AEP event and calls alloy.sendEvent", () => {
                         {
                             currencyCode: "USD",
                             paymentAmount: 30,
-                            paymentType: "other",
+                            paymentType: "credit card",
                             transactionID: "111111",
                         },
                         {
                             currencyCode: "USD",
                             paymentAmount: 39.98,
-                            paymentType: "other",
+                            paymentType: "cash",
                             transactionID: "111111",
                         },
                     ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Payment code xdm is not "hard" enum, so it takes all strings, which is what we now have as the requirement.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/DINT-1312
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
