### PR TITLE
DINT-1585: Custom context is not supported by contextManager

### DIFF
--- a/examples/events/custom-event-override.md
+++ b/examples/events/custom-event-override.md
@@ -12,7 +12,7 @@ const mse = window.magentoStorefrontEvents;
 mse.publish.productPageView(customCtx);
 ```
 
-### Example - adding categories product
+### Example 1 - adding categories product
 
 ```javascript
 magentoStorefrontEvents.publish.productPageView({
@@ -27,5 +27,51 @@ magentoStorefrontEvents.publish.productPageView({
             ],
         },
     ],
+});
+```
+
+### Example 2 - adding custom context before publishing event
+
+```javascript
+const mse = window.magentoStorefrontEvents;
+
+mse.context.setCustom({
+  productListItems: [
+    {
+      productCategories: [
+        {
+          categoryID: "cat_15",
+          categoryName: "summer pants",
+          categoryPath: "pants/mens/summer",
+        },
+      ],
+    },
+  ],
+});
+
+mse.publish.productPageView();
+```
+
+### Example 3 - custom context set in publisher will overwrite custom context set in ACDL before.
+
+In this example page view event will have **Custom Page Name 2** in `web.webPageDetails.name` field
+
+```javascript
+const mse = window.magentoStorefrontEvents;
+
+mse.context.setCustom({
+  web: {
+    webPageDetails: {
+      name: 'Custom Page Name 1'
+    },
+  },
+});
+
+mse.publish.pageView({
+  web: {
+    webPageDetails: {
+      name: 'Custom Page Name 2'
+    },
+  },
 });
 ```

--- a/examples/events/custom-event-override.md
+++ b/examples/events/custom-event-override.md
@@ -52,7 +52,7 @@ mse.context.setCustom({
 mse.publish.productPageView();
 ```
 
-### Example 3 - custom context set in publisher will overwrite custom context set in ACDL before.
+### Example 3 - the custom context set in the publisher overwrites the custom context previously set in ACDL.
 
 In this example page view event will have **Custom Page Name 2** in `web.webPageDetails.name` field
 

--- a/examples/events/custom.md
+++ b/examples/events/custom.md
@@ -33,7 +33,8 @@ mse.publish.custom();
 
 ### Example
 
-Custom event - save for later event.
+Custom event - save for later event. 
+Context set in the `custom()` will override context previously set in `mse.context.setCustom(customCtx)`
 
 ```javascript
 mse.publish.custom({

--- a/packages/storefront-events-sdk/src/Base.ts
+++ b/packages/storefront-events-sdk/src/Base.ts
@@ -33,6 +33,12 @@ export abstract class Base {
 
     // Push event to ACDL
     protected pushEvent(event: EventName, context: CustomContext = {}): void {
+        // if param context.customContext was set as the default by publishManager, it will be removed
+        // so that a separately set custom context can be applied
+        // otherwise param context.customContext will override previously set custom context
+        if (context && context.customContext === undefined) {
+            delete context.customContext;
+        }
         window.adobeDataLayer.push((acdl: AdobeClientDataLayer) => {
             acdl.push({
                 event,

--- a/packages/storefront-events-sdk/src/ContextManager.ts
+++ b/packages/storefront-events-sdk/src/ContextManager.ts
@@ -1,6 +1,6 @@
 import { Base } from "./Base";
 import contexts from "./contexts";
-import {CustomContext} from "./types/contexts";
+import { CustomContext } from "./types/contexts";
 import {
     Account,
     AEP,

--- a/packages/storefront-events-sdk/src/ContextManager.ts
+++ b/packages/storefront-events-sdk/src/ContextManager.ts
@@ -1,5 +1,6 @@
 import { Base } from "./Base";
 import contexts from "./contexts";
+import {CustomContext} from "./types/contexts";
 import {
     Account,
     AEP,
@@ -97,6 +98,14 @@ export default class ContextManager extends Base {
             contexts.EXPERIENCE_PLATFORM_CONNECTOR_EXTENSION_CONTEXT,
             context,
         );
+    }
+
+    getCustom(): CustomContext {
+        return this.getContext<CustomContext>(contexts.CUSTOM_CONTEXT);
+    }
+
+    setCustom(context: CustomContext): void {
+        this.setContext<CustomContext>(contexts.CUSTOM_CONTEXT, context);
     }
 
     getCustomUrl(): CustomUrl {

--- a/packages/storefront-events-sdk/src/contexts.ts
+++ b/packages/storefront-events-sdk/src/contexts.ts
@@ -4,6 +4,7 @@ const contexts = {
     CHANGED_PRODUCTS_CONTEXT: "changedProductsContext",
     CHANNEL_CONTEXT: "channelContext",
     CATEGORY_CONTEXT: "categoryContext",
+    CUSTOM_CONTEXT: "customContext",
     CUSTOM_URL_CONTEXT: "customUrlContext",
     DATA_SERVICES_EXTENSION_CONTEXT: "dataServicesExtensionContext",
     DEBUG_CONTEXT: "debugContext",

--- a/packages/storefront-events-sdk/src/types/contexts.ts
+++ b/packages/storefront-events-sdk/src/types/contexts.ts
@@ -33,6 +33,7 @@ export type ContextName =
     | typeof contexts.CATEGORY_CONTEXT
     | typeof contexts.CHANGED_PRODUCTS_CONTEXT
     | typeof contexts.CHANNEL_CONTEXT
+    | typeof contexts.CUSTOM_CONTEXT
     | typeof contexts.CUSTOM_URL_CONTEXT
     | typeof contexts.DATA_SERVICES_EXTENSION_CONTEXT
     | typeof contexts.DEBUG_CONTEXT
@@ -61,6 +62,7 @@ export type Context = {
     [contexts.CATEGORY_CONTEXT]: Category;
     [contexts.CHANGED_PRODUCTS_CONTEXT]: ChangedProducts;
     [contexts.CHANNEL_CONTEXT]: Channel;
+    [contexts.CUSTOM_CONTEXT]?: CustomContext;
     [contexts.CUSTOM_URL_CONTEXT]: CustomUrl;
     [contexts.DATA_SERVICES_EXTENSION_CONTEXT]?: DataServicesExtension;
     [contexts.DEBUG_CONTEXT]?: Debug;

--- a/packages/storefront-events-sdk/tests/contexts.test.ts
+++ b/packages/storefront-events-sdk/tests/contexts.test.ts
@@ -194,4 +194,11 @@ describe("contexts", () => {
         mdl.context.setContext("custom", context);
         expect(mdl.context.getContext("custom")).toEqual(context);
     });
+
+    test("custom context set by contextManager", () => {
+        const context = generateCustomContext();
+        expect(mdl.context.getCustom()).toBeUndefined();
+        mdl.context.setCustom(context);
+        expect(mdl.context.getCustom()).toEqual(context);
+    });
 });

--- a/packages/storefront-events-sdk/tests/events.test.ts
+++ b/packages/storefront-events-sdk/tests/events.test.ts
@@ -591,6 +591,35 @@ describe("events", () => {
         mdl.publish.addToCart(customContext);
     });
 
+    test("event publisher doesn't block separately set custom context", () => {
+        const customContext = { foo: "bar" };
+
+        const handler = (event: Event) => {
+            expect(event.eventInfo).toEqual({ customContext });
+            expect(mdl.context.getCustom()).toEqual(customContext);
+        };
+
+        mdl.context.setCustom(customContext);
+        mdl.subscribe.addToCart(handler);
+        mdl.publish.addToCart();
+    });
+
+    test("event publisher overrides custom context in eventInfo if it was set before", () => {
+        const generalContext = { foo1: "general" };
+        const eventContext = { foo2: "event" };
+
+        const handler = (event: Event) => {
+            // values are different because custom context was set through context manager
+            // but event info context was filled by publishManager where custom context was overwritten
+            expect(event.eventInfo.customContext).toEqual(eventContext);
+            expect(mdl.context.getCustom()).toEqual(generalContext);
+        };
+
+        mdl.subscribe.pageView(handler);
+        mdl.context.setCustom(generalContext);
+        mdl.publish.pageView(eventContext);
+    });
+
     test("event context data is not persisted in data layer", () => {
         mdl.context.setCustomUrl({ customUrl: "test.com" });
         mdl.publish.pageView();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Issue 1:
contextManager doesn't support setCustom() and getCustom() as described in documentation https://github.com/adobe/commerce-events/blob/main/examples/events/custom.md

Issue 2:
even if custom context was set to ACDL, pushEvent overrides it with empty value

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
