### PR TITLE
DINT-1688: Add EDS storefront template option

### DIFF
--- a/packages/storefront-events-collector/src/types/contexts.d.ts
+++ b/packages/storefront-events-collector/src/types/contexts.d.ts
@@ -223,7 +223,7 @@ type Storefront = {
     websiteCode?: string;
     websiteId: number;
     websiteName: string;
-    storefrontTemplate?: "Luma" | "Hyva" | "AEM CIF" | "Franklin" | "PWA Studio" | "Other";
+    storefrontTemplate?: "Luma" | "EDS" | "Hyva" | "AEM CIF" | "Franklin" | "PWA Studio" | "Other";
 };
 
 type Tracker = {

--- a/packages/storefront-events-collector/tests/utils/mocks/context.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/context.ts
@@ -130,7 +130,7 @@ const mockStorefrontCtx = {
     websiteCode: "website",
     websiteId: 333333,
     websiteName: "website",
-    storefrontTemplate: "Franklin",
+    storefrontTemplate: "EDS",
 };
 
 const mockAepCtx = {

--- a/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
@@ -343,7 +343,7 @@ const mockStorefront: StorefrontInstance = {
     websiteCode: "website",
     websiteId: 333333,
     websiteName: "website",
-    storefrontTemplate: "Franklin",
+    storefrontTemplate: "EDS",
 };
 
 const mockShopper: Shopper = {

--- a/packages/storefront-events-sdk/src/types/schemas/storefrontInstance.ts
+++ b/packages/storefront-events-sdk/src/types/schemas/storefrontInstance.ts
@@ -16,5 +16,5 @@ export type StorefrontInstance = {
     baseCurrencyCode: string;
     storeViewCurrencyCode: string;
     catalogExtensionVersion?: string | null;
-    storefrontTemplate?: "Luma" | "Hyva" | "AEM CIF" | "Franklin" | "PWA Studio" | "Other";
+    storefrontTemplate?: "Luma" | "EDS" | "Hyva" | "AEM CIF" | "Franklin" | "PWA Studio" | "Other";
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://jira.corp.adobe.com/browse/DINT-1688
As Franklin was renamed to EDS, we need to add this name in [commerce-events](https://github.com/adobe/commerce-events/blob/main/packages/storefront-events-sdk/src/types/schemas/storefrontInstance.ts#L19) as well. 

Franklin cannot be removed from option due to BIC

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
