### PR TITLE
DINT-1692: Do not send shoppingCart context for product-view event

### DIFF
--- a/examples/events/product-page-view.md
+++ b/examples/events/product-page-view.md
@@ -19,8 +19,6 @@
 
 [`product`](./example-contexts/mock-product-context.md)
 
-[`shoppingCart`](./example-contexts/mock-shopping-cart-context.md)
-
 ### 🔧 Usage
 
 ```javascript
@@ -32,7 +30,6 @@ const mse = window.magentoStorefrontEvents;
 
 /* set before firing event */
 mse.context.setProduct(productCtx);
-mse.context.setShoppingCart(shoppingCartCtx);
 
 mse.publish.productPageView();
 ```

--- a/packages/storefront-events-collector/src/handlers/product/view.ts
+++ b/packages/storefront-events-collector/src/handlers/product/view.ts
@@ -1,19 +1,14 @@
 import { Event } from "@adobe/magento-storefront-events-sdk/dist/types/types/events";
 import { SelfDescribingJson, trackStructEvent } from "@snowplow/browser-tracker";
 
-import { createProductCtx, createShoppingCartCtx } from "../../contexts";
+import { createProductCtx } from "../../contexts";
 
 const handler = (event: Event): void => {
-    const { pageContext, productContext, shoppingCartContext } = event.eventInfo;
+    const { pageContext, productContext } = event.eventInfo;
 
     const productCtx = createProductCtx(productContext);
-    const shoppingCartCtx = createShoppingCartCtx(shoppingCartContext);
 
     const context: Array<SelfDescribingJson> = [productCtx];
-
-    if (shoppingCartCtx) {
-        context.push(shoppingCartCtx);
-    }
 
     trackStructEvent({
         category: "product",

--- a/packages/storefront-events-collector/tests/handlers/product/view.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/product/view.test.ts
@@ -5,7 +5,7 @@ jest.mock("@adobe/alloy", () => ({ createInstance: jest.fn(() => {}) }));
 
 import { productViewHandler } from "../../../src/handlers";
 import schemas from "../../../src/schemas";
-import { mockEvent, mockProductCtx, mockShoppingCartCtx } from "../../utils/mocks";
+import { mockEvent, mockProductCtx } from "../../utils/mocks";
 
 test("sends snowplow event", () => {
     // we don't send product id to snowplow anymore, but don't want to break mocks for any aep tests
@@ -23,11 +23,7 @@ test("sends snowplow event", () => {
             {
                 data: mockProductCtxNoId,
                 schema: schemas.PRODUCT_SCHEMA_URL,
-            },
-            {
-                data: mockShoppingCartCtx,
-                schema: schemas.SHOPPING_CART_SCHEMA_URL,
-            },
+            }
         ],
     });
 });

--- a/packages/storefront-events-collector/tests/handlers/product/view.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/product/view.test.ts
@@ -9,7 +9,7 @@ import { mockEvent, mockProductCtx } from "../../utils/mocks";
 
 test("sends snowplow event", () => {
     // we don't send product id to snowplow anymore, but don't want to break mocks for any aep tests
-    const { ...mockProductCtxNoId } = mockProductCtx;
+    const { productId, ...mockProductCtxNoId } = mockProductCtx;
 
     productViewHandler(mockEvent);
 

--- a/packages/storefront-events-collector/tests/handlers/product/view.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/product/view.test.ts
@@ -23,7 +23,7 @@ test("sends snowplow event", () => {
             {
                 data: mockProductCtxNoId,
                 schema: schemas.PRODUCT_SCHEMA_URL,
-            }
+            },
         ],
     });
 });

--- a/packages/storefront-events-collector/tests/handlers/product/view.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/product/view.test.ts
@@ -9,7 +9,7 @@ import { mockEvent, mockProductCtx } from "../../utils/mocks";
 
 test("sends snowplow event", () => {
     // we don't send product id to snowplow anymore, but don't want to break mocks for any aep tests
-    const { productId, ...mockProductCtxNoId } = mockProductCtx;
+    const { ...mockProductCtxNoId } = mockProductCtx;
 
     productViewHandler(mockEvent);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
ShoppingCart context from product-view event is not used in queries, but required by commerce-events.

This event should stop sending [sending shoppingCart context for product-view](https://github.com/adobe/commerce-events/blob/main/packages/storefront-events-collector/src/handlers/product/view.ts#L10) event as there is no reason for this.

This change is backward compatible.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
