### PR TITLE
Update deprecated actions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [lts/-n, lts/*]
+                node-version: [lts/*]
         steps:
             - name: checkout
               uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [14.x, 16.x]
+                node-version: [lts/-n, lts/*]
         steps:
             - name: checkout
               uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,19 +14,19 @@ jobs:
                 node-version: [lts/-n, lts/*]
         steps:
             - name: checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                   fetch-depth: 0
                   ref: ${{ github.ref }}
 
             - name: cache
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
             - name: node ${{ matrix.node-version }}
-              uses: actions/setup-node@v2
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
             - name: install dependencies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Updating Node version for the github actions as the previous ones are deprecated
- https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax

Updated Actions library to the latest for "checkout", "cache", and "setup-node" to fix actions issues with deprecated libraries.