### PR TITLE
Fixing linting errors after updating node version and github actions …

### DIFF
--- a/packages/storefront-events-collector/src/alloy.ts
+++ b/packages/storefront-events-collector/src/alloy.ts
@@ -38,7 +38,7 @@ const configure = async (instance: AlloyInstance): Promise<AlloyInstance> => {
 const setExistingAlloy = async (name: string) => {
     try {
         if (window.hasOwnProperty(name)) {
-            alloyInstance = (window as any)[name];
+            alloyInstance = (window as unknown as Record<string, AlloyInstance>)[name];
         } else {
             throw new Error();
         }
@@ -106,15 +106,13 @@ const getCustomIdentityMap = (ecid: string, schema: BeaconSchema): IdentityMap |
     if (config?.identityMap) {
         const hasPrimaryIdentity = Object.values(config.identityMap)
             .flat()
-            .some(identity => identity.primary);
+            .some((identity) => identity.primary);
 
         /**
          * Check if custom identityMap has a primary identity.
          * Otherwise, add ECID as primary, as for RTCP schemas, primary identity is required.
          */
-        return hasPrimaryIdentity
-            ? config.identityMap
-            : {...config.identityMap, ...baseIdentityMap};
+        return hasPrimaryIdentity ? config.identityMap : { ...config.identityMap, ...baseIdentityMap };
     }
 
     // add email to baseIdentityMap if it exists

--- a/packages/storefront-events-collector/src/segments.ts
+++ b/packages/storefront-events-collector/src/segments.ts
@@ -25,7 +25,14 @@ export const setAdobeCommerceAEPSegmentCookies = (userSegmentIds = "") => {
     document.cookie = `${ADOBE_COMMERCE_AEP_SEGMENT_MEMBERSHIP_COOKIE_NAME}=${userSegmentIds};path=/`;
 };
 
-// i'm not sure the shape of this object so i'm just typing as any to avoid errors
-export const getSegmentIds = (destinations = []) => {
-    return destinations.map(({ segments }: any) => segments.map(({ id }: any) => id)).join(",") || "";
-};
+// We're not sure of the shape of the data (destinations) but it should be array of objects with a `segments` key that contains an array of objects with an `id` key
+interface Segment {
+    id: string;
+}
+
+interface Destination {
+    segments: Segment[];
+}
+
+export const getSegmentIds = (destinations: Destination[] = []) =>
+    destinations.map(({ segments }) => segments.map(({ id }) => id)).join(",") || "";

--- a/packages/storefront-events-collector/src/utils/aep/account.ts
+++ b/packages/storefront-events-collector/src/utils/aep/account.ts
@@ -2,7 +2,7 @@ import * as sdkSchemas from "@adobe/magento-storefront-events-sdk/src/types/sche
 
 import { BeaconSchema } from "../../types/aep";
 
-const createAccountPayload = (customContext: any, accountContext: sdkSchemas.Account): BeaconSchema => {
+const createAccountPayload = (customContext: BeaconSchema, accountContext: sdkSchemas.Account): BeaconSchema => {
     let payload: BeaconSchema = {};
     if (customContext && Object.keys(customContext as BeaconSchema).length !== 0) {
         // override payload on custom context

--- a/packages/storefront-events-collector/src/utils/product.ts
+++ b/packages/storefront-events-collector/src/utils/product.ts
@@ -28,6 +28,9 @@ const createProductFromCartItem = (ctx: ShoppingCartItem): ProductContext => {
         regularPrice: ctx.prices.price.value,
         currencyCode: ctx.prices.price.currency || null,
     };
+
+    //I tried to type this correctly, but I would need to cast ctx.product.productId to a string, then to a number, which feels like it could break stuff without a lot of testing.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const productId: any = ctx.product.productId;
 
     const newCtx: Product = {

--- a/packages/storefront-events-collector/tests/contexts/product.test.ts
+++ b/packages/storefront-events-collector/tests/contexts/product.test.ts
@@ -4,6 +4,7 @@ import { mockProductCtx } from "../utils/mocks";
 
 test("creates context", () => {
     // we don't send product id to snowplow anymore, but don't want to break mocks for any aep tests
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { productId, ...mockProductCtxNoId } = mockProductCtx;
 
     const ctx = createProductCtx();

--- a/packages/storefront-events-collector/tests/handlers/product/addToCart.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/product/addToCart.test.ts
@@ -9,6 +9,7 @@ import { mockEvent, mockProductCtx, mockShoppingCartCtx, mockChangedProductsCtx 
 
 test("sends snowplow event", () => {
     // we don't send product id to snowplow anymore, but don't want to break mocks for any aep tests
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { productId, ...mockProductCtxNoId } = mockProductCtx;
 
     addToCartHandler(mockEvent);

--- a/packages/storefront-events-collector/tests/handlers/product/view.test.ts
+++ b/packages/storefront-events-collector/tests/handlers/product/view.test.ts
@@ -9,6 +9,7 @@ import { mockEvent, mockProductCtx } from "../../utils/mocks";
 
 test("sends snowplow event", () => {
     // we don't send product id to snowplow anymore, but don't want to break mocks for any aep tests
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { productId, ...mockProductCtxNoId } = mockProductCtx;
 
     productViewHandler(mockEvent);


### PR DESCRIPTION
[PR 180](https://github.com/adobe/commerce-events/pull/180) is having [linting errors](https://github.com/adobe/commerce-events/actions/runs/13838988852/job/38721283090) in the github actions after updated the versions of actions libs used for the build.

This fixes those linting errors. I've tried to type necessary objects correctly if I could, if not, then I added "eslint ignore" statments. 