### PR TITLE
COMOPT-1216-1217: update sdk & collector packages to support the new viewId attribute

### DIFF
--- a/packages/storefront-events-collector/src/contexts/storefront.ts
+++ b/packages/storefront-events-collector/src/contexts/storefront.ts
@@ -33,6 +33,7 @@ const createContext = (storefront?: StorefrontInstance): StorefrontContext => {
         websiteName: storefrontCtx.websiteName,
         websiteId: storefrontCtx.websiteId,
         storefrontTemplate: storefrontCtx.storefrontTemplate,
+        viewId: storefrontCtx.viewId,
     };
 
     const context: StorefrontContext = {

--- a/packages/storefront-events-collector/src/schemas.ts
+++ b/packages/storefront-events-collector/src/schemas.ts
@@ -16,7 +16,7 @@ const schemas = {
     SEARCH_RESULT_SUGGESTION_SCHEMA_URL: "iglu:com.adobe.magento.entity/search-result-suggestion/jsonschema/1-0-1",
     SHOPPING_CART_SCHEMA_URL: "iglu:com.adobe.magento.entity/shopping-cart/jsonschema/3-0-0",
     SHOPPER_SCHEMA_URL: "iglu:com.adobe.magento.entity/shopper/jsonschema/1-0-0",
-    STOREFRONT_INSTANCE_SCHEMA_URL: "iglu:com.adobe.magento.entity/storefront-instance/jsonschema/3-0-2",
+    STOREFRONT_INSTANCE_SCHEMA_URL: "iglu:com.adobe.magento.entity/storefront-instance/jsonschema/3-0-3",
 };
 
 export default schemas;

--- a/packages/storefront-events-collector/src/types/contexts.d.ts
+++ b/packages/storefront-events-collector/src/types/contexts.d.ts
@@ -225,6 +225,7 @@ type Storefront = {
     websiteId: number;
     websiteName: string;
     storefrontTemplate?: "Luma" | "EDS" | "Hyva" | "AEM CIF" | "Franklin" | "PWA Studio" | "Other";
+    viewId?: string | null;
 };
 
 type Tracker = {

--- a/packages/storefront-events-collector/tests/utils/mocks/context.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/context.ts
@@ -131,7 +131,7 @@ const mockStorefrontCtx = {
     websiteId: 333333,
     websiteName: "website",
     storefrontTemplate: "EDS",
-    viewId: "catalog-view-1", // catalog view identifier
+    viewId: "catalog-view-1",
 };
 
 const mockCcdmStorefrontCtx = {
@@ -151,7 +151,7 @@ const mockCcdmStorefrontCtx = {
     websiteCode: "",
     websiteId: 333333,
     websiteName: "website",
-    viewId: "category-electronics", // catalog view identifier
+    viewId: "catalog-view-1",
     //storefrontTemplate: "EDS",
 };
 
@@ -172,7 +172,7 @@ const mockCcdmStorefrontProcessedCtx = {
     websiteCode: "WEBSITE_CODE",
     websiteId: 333333,
     websiteName: "website",
-    viewId: "category-electronics", // catalog view identifier
+    viewId: "catalog-view-1",
     //storefrontTemplate: "EDS",
 };
 

--- a/packages/storefront-events-collector/tests/utils/mocks/context.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/context.ts
@@ -131,6 +131,7 @@ const mockStorefrontCtx = {
     websiteId: 333333,
     websiteName: "website",
     storefrontTemplate: "EDS",
+    viewId: "catalog-view-1", // catalog view identifier
 };
 
 const mockCcdmStorefrontCtx = {
@@ -150,6 +151,7 @@ const mockCcdmStorefrontCtx = {
     websiteCode: "",
     websiteId: 333333,
     websiteName: "website",
+    viewId: "category-electronics", // catalog view identifier
     //storefrontTemplate: "EDS",
 };
 
@@ -170,6 +172,7 @@ const mockCcdmStorefrontProcessedCtx = {
     websiteCode: "WEBSITE_CODE",
     websiteId: 333333,
     websiteName: "website",
+    viewId: "category-electronics", // catalog view identifier
     //storefrontTemplate: "EDS",
 };
 

--- a/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
@@ -344,6 +344,7 @@ const mockStorefront: StorefrontInstance = {
     websiteId: 333333,
     websiteName: "website",
     storefrontTemplate: "EDS",
+    viewId: "catalog-view-1",
 };
 
 const mockShopper: Shopper = {

--- a/packages/storefront-events-sdk/src/types/schemas/storefrontInstance.ts
+++ b/packages/storefront-events-sdk/src/types/schemas/storefrontInstance.ts
@@ -18,4 +18,5 @@ export type StorefrontInstance = {
     catalogExtensionVersion?: string | null;
     locale?: string | null; // this field should stay null
     storefrontTemplate?: "Luma" | "EDS" | "Hyva" | "AEM CIF" | "Franklin" | "PWA Studio" | "Other";
+    viewId?: string | null; // catalog view identifier
 };

--- a/packages/storefront-events-sdk/tests/mocks.ts
+++ b/packages/storefront-events-sdk/tests/mocks.ts
@@ -409,6 +409,7 @@ export const generateStorefrontInstanceContext = (overrides?: Partial<Storefront
     storeViewName: "Test store view",
     websiteId: 12345,
     websiteName: "test website name",
+    viewId: "category-electronics", // catalog view identifier
     ...overrides,
 });
 

--- a/packages/storefront-events-sdk/tests/mocks.ts
+++ b/packages/storefront-events-sdk/tests/mocks.ts
@@ -409,7 +409,7 @@ export const generateStorefrontInstanceContext = (overrides?: Partial<Storefront
     storeViewName: "Test store view",
     websiteId: 12345,
     websiteName: "test website name",
-    viewId: "category-electronics", // catalog view identifier
+    viewId: "catalog-view-1",
     ...overrides,
 });
 


### PR DESCRIPTION
## Description
Added a new viewId field to the existing storefrontInstance schema and context to support the new catalog view id. A new version of DS is available in snowplow to support it, so the packages are updated to match the same.
Link to snowplow schema -> [HERE](https://console.snowplowanalytics.com/f0aa80a7-0012-46d3-ad4e-5fbe36c22504/data-structures/eb86df699d81efa1018b3e1c394fcaa4981be5b3a8f0233d6c5fcd790611f9ed)

## Related Issue
https://jira.corp.adobe.com/browse/COMOPT-1216
https://jira.corp.adobe.com/browse/COMOPT-1217

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Verified that all existing unit tests pass with no issues when the new viewId is included. The new field is made optional, so no existing flows will break.

## Screenshots (if appropriate): N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x ] I have read the **CONTRIBUTING** document.
-   [ x] I have added tests to cover my changes.
-   [x ] All new and existing tests passed.
