### PR TITLE
COMOPT-1318: Update snowplow urls to be dynamic based on storefrontInstance environment

### DIFF
--- a/packages/storefront-events-collector/src/types/index.d.ts
+++ b/packages/storefront-events-collector/src/types/index.d.ts
@@ -3,9 +3,6 @@ import { MagentoStorefrontEvents } from "@adobe/magento-storefront-events-sdk";
 import { AlloyInstance } from "../aep/types";
 
 declare global {
-    const SNOWPLOW_COLLECTOR_URL: string;
-    const SNOWPLOW_COLLECTOR_PATH: string;
-
     interface Window {
         __alloyNS: string[];
         magentoStorefrontEvents: MagentoStorefrontEvents;

--- a/packages/storefront-events-collector/webpack.dev.js
+++ b/packages/storefront-events-collector/webpack.dev.js
@@ -1,14 +1,7 @@
-const webpack = require("webpack");
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
     mode: "development",
     devtool: "eval-source-map",
-    plugins: [
-        new webpack.DefinePlugin({
-            SNOWPLOW_COLLECTOR_URL: JSON.stringify("https://com-magento-qa1.collector.snplow.net"),
-            SNOWPLOW_COLLECTOR_PATH: JSON.stringify("/com.snowplowanalytics.snowplow/tp2"),
-        }),
-    ],
 });

--- a/packages/storefront-events-collector/webpack.prod.js
+++ b/packages/storefront-events-collector/webpack.prod.js
@@ -1,13 +1,6 @@
-const webpack = require("webpack");
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
     mode: "production",
-    plugins: [
-        new webpack.DefinePlugin({
-            SNOWPLOW_COLLECTOR_URL: JSON.stringify("https://commerce.adobedc.net"),
-            SNOWPLOW_COLLECTOR_PATH: JSON.stringify("/collector/tp2"),
-        }),
-    ],
 });

--- a/packages/storefront-events-collector/webpack.qa.js
+++ b/packages/storefront-events-collector/webpack.qa.js
@@ -1,14 +1,7 @@
-const webpack = require("webpack");
 const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
     mode: "development",
     devtool: "eval-source-map",
-    plugins: [
-        new webpack.DefinePlugin({
-            SNOWPLOW_COLLECTOR_URL: JSON.stringify("https://com-magento-qa1.collector.snplow.net"),
-            SNOWPLOW_COLLECTOR_PATH: JSON.stringify("/com.snowplowanalytics.snowplow/tp2"),
-        }),
-    ],
 });


### PR DESCRIPTION
## Description
Problem: Snowplow endpoints were hardcoded at build time via webpack, forcing events to the prod collector regardless of the storefront’s runtime environment.

Solution: Added a small config and runtime routing based on storefrontInstance.environment (qa/stage/test → QA; otherwise → Prod), preserving eventForwarding behavior and enabling a single build to work across environments.

The snowplow url defaults to `production` when no environment is detected or matches with the qa options, so the existing functionality will still work as it is without any issues.

## Related Issue
https://jira.corp.adobe.com/browse/COMOPT-1318

## Motivation and Context
Problem: Snowplow endpoints were hardcoded at build time via webpack, forcing events to the prod collector regardless of the storefront’s runtime environment.

## How Has This Been Tested?

- Built the package (webpack prod) to ensure compilation succeeded.
- Ran the full Jest suite; all existing tests passed.

The snowplow url defaults to `production` when no environment is detected or matches with the qa options, so the existing functionality will still work as it is without any issues.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
