### PR TITLE
Use production mode in QA webpack config

### DIFF
--- a/packages/storefront-events-collector/webpack.qa.js
+++ b/packages/storefront-events-collector/webpack.qa.js
@@ -3,8 +3,7 @@ const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
-    mode: "development",
-    devtool: "eval-source-map",
+    mode: "production",
     plugins: [
         new webpack.DefinePlugin({
             SNOWPLOW_COLLECTOR_URL: JSON.stringify("https://com-magento-qa1.collector.snplow.net"),

--- a/packages/storefront-events-sdk/webpack.qa.js
+++ b/packages/storefront-events-sdk/webpack.qa.js
@@ -2,6 +2,5 @@ const { merge } = require("webpack-merge");
 const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
-    mode: "development",
-    devtool: "eval-source-map",
+    mode: "production",
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changing QA webpack configuration mode to "production" to allow boilerplate to use QA build of the commerce events libraries.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
