### PR TITLE
fix: update package name references

### DIFF
--- a/packages/storefront-events-collector/README.md
+++ b/packages/storefront-events-collector/README.md
@@ -18,13 +18,13 @@ The collector can be used as a hosted script, or bundled in a JavaScript applica
 To load the Collector as a script, use the following snippet.
 
 ```
-<script src="https://cdn.jsdelivr.net/npm/@adobe/commerce-events-collectors/dist/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@adobe/magento-storefront-event-collector/dist/index.js"></script>
 ```
 
 To install the script as a dependency, run this command.
 
 ```shell
-npm install @adobe/commerce-events-collectors
+npm install @adobe/magento-storefront-event-collector
 ```
 
 ## Quick start
@@ -32,7 +32,7 @@ npm install @adobe/commerce-events-collectors
 After loading the collector script, or importing the package as shown below, there is nothing else that needs to be done.
 
 ```javascript
-import "@adobe/commerce-events-collectors";
+import "@adobe/magento-storefront-event-collector";
 ```
 
 ## Usage
@@ -301,15 +301,15 @@ If you have any questions or encounter any issues, please reach out at these loc
 
 -   [GitHub][issues]
 
-[npm]: https://npmjs.com/package/@adobe/commerce-events-collectors
+[npm]: https://npmjs.com/package/@adobe/magento-storefront-event-collector
 [version-badge]: https://img.shields.io/npm/v/@adobe/magento-storefront-event-collector.svg?style=flat-square
 [downloads-badge]: https://img.shields.io/npm/dt/@adobe/magento-storefront-event-collector?style=flat-square
 [bundlephobia]: https://bundlephobia.com/result?p=@adobe/magento-storefront-event-collector
 [size-badge]: https://img.shields.io/bundlephobia/minzip/@adobe/magento-storefront-event-collector?style=flat-square
 [actions]: https://github.com/adobe/commerce-events/actions
 [build-badge]: https://img.shields.io/github/workflow/status/adobe/magento-storefront-event-collector/merge-to-main?style=flat-square
-[typescript]: https://typescriptlang.org/dt/search?search=%40adobe%2Fcommerce-events-collectors
-[typescript-badge]: https://img.shields.io/npm/types/@adobe/commerce-events-collectors?style=flat-square
+[typescript]: https://typescriptlang.org/dt/search?search=%40adobe%2Fmagento-storefront-event-collector
+[typescript-badge]: https://img.shields.io/npm/types/@adobe/magento-storefront-event-collector?style=flat-square
 [contributing]: https://github.com/adobe/commerce-events/blob/main/.github/CONTRIBUTING.md
 [contributing-badge]: https://img.shields.io/badge/PRs-welcome-success?style=flat-square
 [sdk]: https://npmjs.com/package/@adobe/magento-storefront-events-sdk

--- a/packages/storefront-events-collector/package.json
+++ b/packages/storefront-events-collector/package.json
@@ -17,7 +17,7 @@
         "type": "git",
         "url": "git+https://github.com/adobe/commerce-events"
     },
-    "homepage": "https://github.com/adobe/commerce-events/tree/main/packages/commerce-events-collectors#readme",
+    "homepage": "https://github.com/adobe/commerce-events/tree/main/packages/storefront-events-collector#readme",
     "bugs": {
         "url": "https://github.com/adobe/commerce-events/issues"
     },

--- a/packages/storefront-events-sdk/README.md
+++ b/packages/storefront-events-sdk/README.md
@@ -27,13 +27,13 @@ This SDK can be used as a hosted script, or bundled in a JavaScript application.
 To load the SDK as a script, use the following snippet.
 
 ```
-<script src="https://cdn.jsdelivr.net/npm/@adobe/commerce-events-sdk/dist/index.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@adobe/magento-storefront-events-sdk/dist/index.js"></script>
 ```
 
 To install the script as a dependency, run this command.
 
 ```shell
-npm install @adobe/commerce-events-sdk
+npm install @adobe/magento-storefront-events-sdk
 ```
 
 ## Quick start
@@ -50,7 +50,7 @@ Below is a code example of how to get started.
 **IMPORTANT** Relevant context data must be populated before publishing events that require it.
 
 ```javascript
-import mse from "@adobe/commerce-events-sdk";
+import mse from "@adobe/magento-storefront-events-sdk";
 // handler - can go in a different module
 function addToCartHandler(event) {
     // do something with the event
@@ -134,8 +134,8 @@ If you have any questions or encounter any issues, please reach out on [GitHub][
 [size-badge]: https://img.shields.io/bundlephobia/minzip/@adobe/magento-storefront-events-sdk?style=flat-square
 [actions]: https://github.com/adobe/commerce-events/actions
 [build-badge]: https://img.shields.io/github/workflow/status/adobe/commerce-events/publish-latest?style=flat-square
-[typescript]: https://typescriptlang.org/dt/search?search=%40adobe%2Fcommerce-events-sdk
-[typescript-badge]: https://img.shields.io/npm/types/@adobe/commerce-events-sdk?style=flat-square
+[typescript]: https://typescriptlang.org/dt/search?search=%40adobe%2Fmagento-storefront-events-sdk
+[typescript-badge]: https://img.shields.io/npm/types/@adobe/magento-storefront-events-sdk?style=flat-square
 [contributing]: https://github.com/adobe/commerce-events/blob/main/.github/CONTRIBUTING.md
 [contributing-badge]: https://img.shields.io/badge/PRs-welcome-success?style=flat-square
 [commerce]: https://business.adobe.com/products/magento/magento-commerce.html


### PR DESCRIPTION
## Description

Updated all documentation references from the package names (`@adobe/commerce-events-sdk` and `@adobe/commerce-events-collectors`) to the current package names (`@adobe/magento-storefront-events-sdk` and `@adobe/magento-storefront-event-collector`).

The packages were attempted to be renamed at some point, but the documentation still contained mixed references to both the old and new package names, which could cause confusion for users trying to install or reference these packages.

## Related Issue

N/A - Documentation cleanup to fix inconsistent package naming

## Motivation and Context

The codebase had inconsistent package name references:
- The `package.json` files used the correct `@adobe/magento-storefront-*` naming
- The README files had mixed references to both old (`@adobe/commerce-events-*`) and new names
- This created confusion about which package names users should actually use when installing or importing

This change ensures all documentation consistently uses the current official package names.

## How Has This Been Tested?

- Verified all references to `commerce-events-collectors` and `commerce-events-sdk` have been removed using grep
- Confirmed package.json files already contained the correct package names
- No code changes were made, only documentation updates

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. _(N/A - documentation only)_
- [x] All new and existing tests passed.

## Files Changed

### `packages/storefront-events-collector/README.md`
- Updated CDN script tag reference
- Updated npm install command
- Updated import statement example
- Updated npm package link
- Updated TypeScript badge and search links

### `packages/storefront-events-sdk/README.md`
- Updated CDN script tag reference
- Updated npm install command
- Updated import statement example
- Updated TypeScript badge and search links

### `packages/storefront-events-collector/package.json`
- Fixed homepage URL to reference correct package directory path