### PR TITLE
DSCS-2313: detect ACO merchants by viewId and normalize scope codes to placeholders

### DIFF
--- a/packages/storefront-events-collector/src/utils/ccdm.ts
+++ b/packages/storefront-events-collector/src/utils/ccdm.ts
@@ -2,18 +2,13 @@ import { StorefrontInstance } from "@adobe/magento-storefront-events-sdk/dist/ty
 
 /** returns part of storefront instance data which should be set for CCDM customers */
 export const getCcdmData = (storefrontCtx: StorefrontInstance): object => {
-    // If locale is not empty, and scope codes are empty -  it is CCDM customer, otherwise returns empty object
-    if (
-        !storefrontCtx?.locale ||
-        storefrontCtx?.storeViewCode ||
-        storefrontCtx?.storeCode ||
-        storefrontCtx?.websiteCode
-    ) {
+    // ACO merchants are identified by viewId; normalize scope codes to known placeholders
+    if (!storefrontCtx?.viewId) {
         return {};
     }
 
     return {
-        storeViewCode: storefrontCtx.locale,
+        storeViewCode: "STORE_VIEW_CODE",
         storeCode: "STORE_CODE",
         websiteCode: "WEBSITE_CODE",
     };

--- a/packages/storefront-events-collector/tests/contexts/storefront.test.ts
+++ b/packages/storefront-events-collector/tests/contexts/storefront.test.ts
@@ -1,3 +1,4 @@
+import { StorefrontInstance } from "@adobe/magento-storefront-events-sdk/dist/types/types/schemas";
 import { createStorefrontInstanceCtx } from "../../src/contexts";
 import schemas from "../../src/schemas";
 import { mockStorefrontCtx, mockCcdmStorefrontCtx, mockCcdmStorefrontProcessedCtx } from "../utils/mocks";
@@ -20,4 +21,23 @@ test("creates storefront context for ccdm", () => {
     });
 });
 
-// ToDO: add cases when locale exists but scope codes are not empty
+test("injects placeholders even when viewId is set and scope codes are also set", () => {
+    const ctx = createStorefrontInstanceCtx({
+        ...mockCcdmStorefrontCtx,
+        storeViewCode: "default",
+        storeCode: "main_website_store",
+        websiteCode: "base",
+    });
+
+    expect(ctx.data.storeViewCode).toBe("STORE_VIEW_CODE");
+    expect(ctx.data.storeCode).toBe("STORE_CODE");
+    expect(ctx.data.websiteCode).toBe("WEBSITE_CODE");
+});
+
+test("does not inject placeholders when viewId is not set", () => {
+    const ctx = createStorefrontInstanceCtx(mockStorefrontCtx as StorefrontInstance);
+
+    expect(ctx.data.storeViewCode).toBe("default");
+    expect(ctx.data.storeCode).toBe("magento");
+    expect(ctx.data.websiteCode).toBe("website");
+});

--- a/packages/storefront-events-collector/tests/utils/mocks/context.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/context.ts
@@ -131,7 +131,6 @@ const mockStorefrontCtx = {
     websiteId: 333333,
     websiteName: "website",
     storefrontTemplate: "EDS",
-    viewId: "12345678-1234-1234-1234-123456789abc",
 };
 
 const mockCcdmStorefrontCtx = {
@@ -165,7 +164,7 @@ const mockCcdmStorefrontProcessedCtx = {
     storeId: 111111,
     storeName: "magento",
     storeUrl: "https://magento.com",
-    storeViewCode: "en_US",
+    storeViewCode: "STORE_VIEW_CODE",
     storeViewCurrencyCode: "USD",
     storeViewId: 222222,
     storeViewName: "default",

--- a/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
+++ b/packages/storefront-events-collector/tests/utils/mocks/dataLayer.ts
@@ -344,7 +344,6 @@ const mockStorefront: StorefrontInstance = {
     websiteId: 333333,
     websiteName: "website",
     storefrontTemplate: "EDS",
-    viewId: "12345678-1234-1234-1234-123456789abc",
 };
 
 const mockShopper: Shopper = {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes `getCcdmData()` in the storefront events collector to detect CCDM merchants
by `viewId` instead of `locale`. When `viewId` is present, scope codes are always
overridden with standard placeholders (`STORE_VIEW_CODE`, `STORE_CODE`, `WEBSITE_CODE`)
regardless of any values configured by the merchant.

## Related Issue

https://jira.corp.adobe.com/browse/DSCS-2313

## Motivation and Context

`locale` was the original detection signal for CCDM merchants before `viewId` was
introduced. `viewId` is the identifier for CCDM merchants and is used consistently
across the pipeline. This change aligns the collector with that.

## How Has This Been Tested?

- Updated existing unit tests to reflect the new behavior
- Added two new test cases: one verifying placeholders are injected even when scope
  codes are also set, and one verifying non-CCDM merchants (no `viewId`) are unaffected
- Full test suite run: 55/55 tests passing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have read the **CONTRIBUTING** document.
-   [x] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
