### PR TITLE
bump version to 1.18.0

### DIFF
--- a/packages/storefront-events-collector/package.json
+++ b/packages/storefront-events-collector/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/magento-storefront-event-collector",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "description": "Event Collectors for Adobe Commerce storefronts",
     "license": "MIT",
     "main": "./dist/index.js",

--- a/packages/storefront-events-sdk/package.json
+++ b/packages/storefront-events-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@adobe/magento-storefront-events-sdk",
-    "version": "1.17.0",
+    "version": "1.18.0",
     "description": "SDK for working with events on an Adobe Commerce storefront",
     "license": "MIT",
     "main": "./dist/index.js",


### PR DESCRIPTION
bump version to 1.18.0. includes changes in the storefront events collector to detect CCDM merchants
by viewId instead of locale